### PR TITLE
Fixed the use of the zoom feature when you use the base tag html.

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -157,7 +157,7 @@
         /*-- Set Variables --*/
 
         var clipId = __bindto.replace('#', '') + '-clip',
-            clipPath = "url("+document.URL+"#" + clipId + ")";
+            clipPath = "url(" + document.URL + "#" + clipId + ")";
 
         var isTimeSeries = (__axis_x_type === 'timeseries'),
             isCategorized = (__axis_x_type === 'categorized'),


### PR DESCRIPTION
Fixed the use of the zoom feature when you use the <base tag html. TODO: compile also the c3.min.js.

Related issues, please read:
https://github.com/mbostock/d3/issues/1510
http://stackoverflow.com/questions/18259032/using-base-tag-on-a-page-that-contains-svg-marker-elements-fails-to-render-marke/18265336#18265336
