### PR TITLE
adding date month year option to api for ease of use

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -414,12 +414,24 @@
             return id in __data_axes ? __data_axes[id] : 'y';
         }
         function getXAxisTickFormat() {
+            var monthNames = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
             var format = isTimeSeries ? defaultTimeFormat : isCategorized ? category : null;
             if (__axis_x_tick_format) {
                 if (typeof __axis_x_tick_format === 'function') {
                     format = __axis_x_tick_format;
                 } else if (isTimeSeries) {
+                    if (__axis_x_tick_format === 'dateMonthYear'){
+                        format = function (date) {
+                            if (date !== undefined){
+                                var shortYear = date.getFullYear().toString().substring(2,4);
+                                return ''+ date.getDate()+' '+ monthNames[date.getMonth()] +' '+ shortYear;
+                            }
+                        }
+                    } else {
                     format = function (date) { return d3.time.format(__axis_x_tick_format)(date); };
+                  }
+
                 }
             }
             return format;


### PR DESCRIPTION
For ease of using, adding option for day-month-year in the api might be a nice feature?

![screen shot 2014-03-13 at 20 11 01](https://f.cloud.github.com/assets/5793128/2414569/b3507010-aaeb-11e3-93e8-e7dd731d0cf2.png)

results in:

![screen shot 2014-03-13 at 20 12 11](https://f.cloud.github.com/assets/5793128/2414580/d7d173bc-aaeb-11e3-847d-08e6cfd39df1.png)
