### PR TITLE
Fix for AMD define

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -3932,7 +3932,7 @@
     }
 
     if (typeof window.define === "function" && window.define.amd) {
-        window.define(c3);
+        window.define("c3", ["d3"], c3);
     } else {
         window.c3 = c3;
     }


### PR DESCRIPTION
Hi,

I ran into trouble when using C3 together with requirejs [optimizer rjs](http://requirejs.org/docs/optimization.html). To avoid this trouble the C3 module should explicitly declare d3 as a requirement. This simple PR will fix this.
