### PR TITLE
Arc of Gauge to expand on mouseover

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -257,6 +257,7 @@
         // gauge
         var __gauge_label_show = getConfig(['gauge', 'label', 'show'], true),
             __gauge_label_format = getConfig(['gauge', 'label', 'format']),
+            __gauge_expand = getConfig(['gauge', 'expand'], true),
             __gauge_min = getConfig(['gauge', 'min'], 0),
             __gauge_max = getConfig(['gauge', 'max'], 100),
             __gauge_onclick = getConfig(['gauge', 'onclick'], function () {}),
@@ -2156,7 +2157,7 @@
         }
 
         function shouldExpand(id) {
-            return (isDonutType(id) && __donut_expand) || (isPieType(id) && __pie_expand);
+            return (isDonutType(id) && __donut_expand) || (isGaugeType(id) && __gauge_expand) || (isPieType(id) && __pie_expand);
         }
 
         //-- Color --//


### PR DESCRIPTION
I noticed that the mouseover effect of expanding and contracting was not happening with the arc gauge. I thought it was working before, and I don't know if it was taken out on purpose or left out during the refactoring of the arc portion of the code. Here is a fix that is structured the same way the donut and pie chart options work.
