### PR TITLE
transformForArcLabel NaN error.

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -1031,8 +1031,8 @@
             var updated = updateAngle(d), c, x, y, h, ratio, translate = "";
             if (updated && !hasGaugeType(c3.data.targets)) {
                 c = svgArc.centroid(updated);
-                x = c[0];
-                y = c[1];
+                x = isNaN(c[0]) ? 0 : c[0];
+                y = isNaN(c[1]) ? 0 : c[1];
                 h = Math.sqrt(x * x + y * y);
                 // TODO: ratio should be an option?
                 ratio = radius && h ? (36 / radius > 0.375 ? 1.175 - 36 / radius : 0.8) * radius / h : 0;


### PR DESCRIPTION
Sometimes the data provided can't be used for <code>transformForArcLabel</code> (a stacked area chart where registered items came back as neither connected nor disconnected. http://jsfiddle.net/U5g3h/). I find that the <code>startAngle</code> and <code>endAngle</code> values arrived as <code>NaN</code>. To fix this I am checking before assigning <code>x</code> and <code>y</code>.
