### PR TITLE
Fix for #309

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -2415,6 +2415,9 @@
                     }, 10);
                 };
             f.add = function (transition) {
+                if (!hasFlow) {
+                  return transition;
+                }
                 transitionsToWait.push(transition);
             };
             return f;
@@ -4051,45 +4054,45 @@
                 waitForDraw.add(mainBar.transition()
                     .attr('d', drawBar)
                     .style("fill", color)
-                    .style("opacity", 1));
+                    .style("opacity", 1), !!options.flow);
                 waitForDraw.add(mainLine.transition()
                     .attr("d", drawLine)
                     .style("stroke", color)
-                    .style("opacity", 1));
+                    .style("opacity", 1), !!options.flow);
                 waitForDraw.add(mainArea.transition()
                     .attr("d", drawArea)
                     .style("fill", color)
-                    .style("opacity", orgAreaOpacity));
+                    .style("opacity", orgAreaOpacity), !!options.flow);
                 waitForDraw.add(mainCircle.transition()
                     .style('opacity', opacityForCircle)
                     .style("fill", color)
                     .attr("cx", __axis_rotated ? circleY : circleX)
-                    .attr("cy", __axis_rotated ? circleX : circleY));
+                    .attr("cy", __axis_rotated ? circleX : circleY), !!options.flow);
                 waitForDraw.add(main.selectAll('.' + CLASS.selectedCircle).transition()
                     .attr("cx", __axis_rotated ? circleY : circleX)
-                    .attr("cy", __axis_rotated ? circleX : circleY));
+                    .attr("cy", __axis_rotated ? circleX : circleY), !!options.flow);
                 waitForDraw.add(mainText.transition()
                     .attr('x', xForText)
                     .attr('y', yForText)
                     .style("fill", color)
-                    .style("fill-opacity", options.flow ? 0 : opacityForText));
+                    .style("fill-opacity", options.flow ? 0 : opacityForText), !!options.flow);
                 waitForDraw.add(mainRegion.selectAll('rect').transition()
                     .attr("x", regionX)
                     .attr("y", regionY)
                     .attr("width", regionWidth)
                     .attr("height", regionHeight)
-                    .style("fill-opacity", function (d) { return isValue(d.opacity) ? d.opacity : 0.1; }));
+                    .style("fill-opacity", function (d) { return isValue(d.opacity) ? d.opacity : 0.1; }), !!options.flow);
                 waitForDraw.add(xgridLines.select('line').transition()
                     .attr("x1", __axis_rotated ? 0 : xv)
                     .attr("x2", __axis_rotated ? width : xv)
                     .attr("y1", __axis_rotated ? xv : margin.top)
                     .attr("y2", __axis_rotated ? xv : height)
-                    .style("opacity", 1));
+                    .style("opacity", 1), !!options.flow);
                 waitForDraw.add(xgridLines.select('text').transition()
                     .attr("x", __axis_rotated ? width : 0)
                     .attr("y", xv)
                     .text(function (d) { return d.text; })
-                    .style("opacity", 1));
+                    .style("opacity", 1), !!options.flow);
             })
             .call(waitForDraw, options.flow ? function () { // only for flow
                 var translateX, scaleX = 1, transform,


### PR DESCRIPTION
The original behavior prior to 2deefb3 had no interval wait times set to process the transitions. When bypassing the wait, the draw of the graph no longer has intermittent failure due to the intervals across graphs interfering with each other. It feels backwards for the default behavior to be the conditional, but I think it would be more code to reverse it at this time.
