### PR TITLE
Fix x-grid-lines to not get pushed down by top padding.

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -2964,13 +2964,15 @@
                   .append('line')
                     .attr('class', CLASS.xgridFocus);
             }
-            grid.append('g').attr("class", CLASS.xgridLines);
 
             // Y-Grid
             if (__grid_y_show) {
                 grid.append('g').attr('class', CLASS.ygrids);
             }
             grid.append('g').attr('class', CLASS.ygridLines);
+			
+			// Append the xgridLine here so it does not get overlapped by y-grids
+            grid.append('g').attr("class", CLASS.xgridLines);
 
             // Define g for chart area
             main.append('g')


### PR DESCRIPTION
Fix additional problem with Issue #368 related to x-grid-lines.  Padding should not push down x-grid-lines.

Without Fix:
http://jsfiddle.net/99XZt/3/

With Fix:
http://jsfiddle.net/99XZt/4/
