### PR TITLE
Fix disappearing tooltips with lots of segments.

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -2063,7 +2063,7 @@
                 if (tooltipRight > chartRight) {
                     tooltipLeft -= tooltipRight - chartRight;
                 }
-                if (tooltipTop + tHeight > getCurrentHeight()) {
+                if (tooltipTop + tHeight > getCurrentHeight() && tooltipTop > tHeight + 30) {
                     tooltipTop -= tHeight + 30;
                 }
             }


### PR DESCRIPTION
This fixes an issue with tooltips disappearing when graphs are close to the top of the page and have lots of segments, causing them to be bigger than the chart height.
