### PR TITLE
#587 Graph labeling issue

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -255,7 +255,7 @@ c3_chart_internal_fn.getMaxTickWidth = function (id) {
             scale = $$.x.copy().domain($$.getXDomain(targetsToShow));
             axis = $$.getXAxis(scale, $$.xOrient, $$.getXAxisTickFormat(), config.axis_x_tick_values ? config.axis_x_tick_values : $$.xAxis.tickValues());
         }
-        $$.d3.select('body').append("g").style('visibility', 'hidden').call(axis).each(function () {
+        $$.svg.append("g").style('visibility', 'hidden').call(axis).each(function () {
             $$.d3.select(this).selectAll('text').each(function () {
                 var box = this.getBoundingClientRect();
                 if (maxWidth < box.width) { maxWidth = box.width; }


### PR DESCRIPTION
Graphs with large labels cause the graph to be pushed outside the svg bounds and hidden.

This is caused by the tick width test which adds hidden tags to the html body element to check their size. However by adding to the body they can wrap around if all the labels together are longer than the size of the HTML page, this wrapping happens within a tick label element which then returns a width of the size of the page (because it starts at one side and wraps back to the other).

By adding the hidden tick elements to the svg element they don't have the same flow logic applied by the browser and return the correct size.

There seem to be some other areas which use the same method to test sizes, and these might also benefit from using the SVG tag as element which they are added to.
