### PR TITLE
New option for do not want to generateTickValues.

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -468,7 +468,9 @@
             $$.updateXDomain(targetsToShow, withUpdateXDomain, withUpdateOrgXDomain, withTrimXDomain);
             if (!config.axis_x_tick_values) {
                 if (config.axis_x_tick_fit || config.axis_x_tick_count) {
-                    tickValues = $$.generateTickValues($$.mapTargetsToUniqueXs(targetsToShow), config.axis_x_tick_count, $$.isTimeSeries());
+                    if ( config.axis_x_tick_autoGenerate ){
+                        tickValues = $$.generateTickValues($$.mapTargetsToUniqueXs(targetsToShow), config.axis_x_tick_count, $$.isTimeSeries());
+                    }
                 } else {
                     tickValues = undefined;
                 }
@@ -975,6 +977,7 @@
             axis_x_type: 'indexed',
             axis_x_localtime: true,
             axis_x_categories: [],
+            axis_x_tick_autoGenerate: false,
             axis_x_tick_centered: false,
             axis_x_tick_format: undefined,
             axis_x_tick_culling: {},


### PR DESCRIPTION
I found tick value auto generate and flash effect when using axis.x.tick.fit or count with redraw. 

I'm just want to keep tick value. And I think that default should be false.  

So if user set { autoGenerate: true } that will do generate tick value.

C3 is great!! Thanks.
