### PR TITLE
Adding a note re: issue queue to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,24 @@ $ cd c3/htdocs
 $ python -m SimpleHTTPServer 8080
 ```
 
-## Forum
-Discuss anything in this forum:
-+ [https://groups.google.com/forum/#!forum/c3js](https://groups.google.com/forum/#!forum/c3js)
+## Google Group
+For general C3.js-related discussion, please visit our [Google Group at https://groups.google.com/forum/#!forum/c3js](https://groups.google.com/forum/#!forum/c3js).
+
+## Using the issue queue
+The [issue queue](https://github.com/masayuki0812/c3/issues) is to be used for reporting defects and problems with C3.js, in addition to feature requests and ideas. It is **not** a catch-all support forum. **For general support enquiries, please use the [Google Group](https://groups.google.com/forum/#!forum/c3js) at https://groups.google.com/forum/#!forum/c3js.** All questions involving the interplay between C3.js and any other library (such as AngularJS) should be posted there first!
+
+Before reporting an issue, please do the following:
+1. [Search for existing issues](https://github.com/masayuki0812/c3/issues) to ensure you're not posting a duplicate.
+
+1.  [Search the Google Group](https://groups.google.com/forum/#!forum/c3js) to ensure it hasn't been addressed there already.
+
+1. Create a JSFiddle or Plunkr highlighting the issue. Please don't include any unnecessary dependencies so we can isolate that the issue is in fact with C3. *Please be advised that custom CSS can modify C3.js output!*
+
+1. When posting the issue, please use a descriptive title and include the version of C3 (or, if cloning from Git, the commit hash — C3 is under active development and the master branch contains the latest dev commits!), along with any platform/browser/OS information that may be relevant.
+
+## Pull requests
+Pull requests are welcome, though please post an issue first to see whether such a change is desirable.
+If you choose to submit a pull request, please do not bump the version number unless asked to, and please include test cases for any new features!
 
 ## Playground
 Please fork this fiddle:


### PR DESCRIPTION
Figured it would help to add a note to the README explaining issue queue etiquette. If we can get even one of the 5-10 issues opened a day (many of which are support requests) to use the Google Group instead, it would be well worth it.
