### PR TITLE
Explicitly set auto width for tooltip

### DIFF
--- a/c3.css
+++ b/c3.css
@@ -160,6 +160,7 @@
   border-spacing:0;
   background-color:#fff;
   empty-cells:show;
+  width:auto;
   -webkit-box-shadow: 7px 7px 12px -9px rgb(119,119,119);
      -moz-box-shadow: 7px 7px 12px -9px rgb(119,119,119);
           box-shadow: 7px 7px 12px -9px rgb(119,119,119);


### PR DESCRIPTION
c3's tooltip depends on the default behavior for table table width. However,
site stylesheets and CSS frameworks will often change the default table width.
This can completely break the rendering of the tooltip (e.g. when table width is
set to 100%, the tooltip will stretch from a left position in the negative
thousands all the way to the right of the chart). Explicitly setting
`width:auto;` for the tooltip allows c3 to play nicely with CSS frameworks and
site stylesheets.
