### PR TITLE
Load now refreshes x tick format via xtickformat parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ d3.min.js
 components
 build
 .sass-cache
+.idea
+.grunt
+_SpecRunner.html

--- a/spec/api.load-spec.js
+++ b/spec/api.load-spec.js
@@ -118,4 +118,49 @@ describe('c3 api load', function () {
 
     });
 
+    describe('timeseries data', function(){
+
+        describe('as column', function(){
+
+            it('should update args', function () {
+                args = {
+                    data: {
+                        x: 'x',
+                        columns: [
+                            ['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
+                            ['data1', 30, 200, 100, 400, 150, 250]
+                        ]
+                    },
+                    axis: {
+                        x: {
+                            type: 'timeseries',
+                            tick: {
+                                format: '%Y-%m-%d'
+                            }
+                        }
+                    }
+                };
+                expect(true).toBeTruthy();
+            });
+
+            it('should update x axis format', function (done) {
+                var main = chart.internal.main;
+                setTimeout(function () {
+                    var target = main.select('.c3-axis.c3-axis-x').select('tspan');
+                    expect(target.text()).toBe('2013-01-01');
+
+                    chart.load({
+                        xtickformat: '%Y'
+                    });
+                    setTimeout(function () {
+                        var target = main.select('.c3-axis.c3-axis-x').select('tspan');
+                        expect(target.text()).toBe('2013');
+                        done();
+                    }, 500);
+                }, 500);
+
+            });
+        });
+    });
+
 });

--- a/src/api.load.js
+++ b/src/api.load.js
@@ -26,6 +26,12 @@ c3_chart_fn.load = function (args) {
             config.data_colors[id] = args.colors[id];
         });
     }
+
+    // update x axis tick format if exists
+    if ('xtickformat' in args) {
+        config.axis_x_tick_format = args.xtickformat;
+    }
+
     // use cache if exists
     if ('cacheIds' in args && $$.hasCaches(args.cacheIds)) {
         $$.load($$.getCaches(args.cacheIds), args.done);

--- a/src/data.load.js
+++ b/src/data.load.js
@@ -29,7 +29,7 @@ c3_chart_internal_fn.load = function (targets, args) {
     $$.updateTargets($$.data.targets);
 
     // Redraw with new targets
-    $$.redraw({withUpdateOrgXDomain: true, withUpdateXDomain: true, withLegend: true});
+    $$.redraw({withUpdateOrgXDomain: true, withUpdateXAxis: true, withLegend: true});
 
     if (args.done) { args.done(); }
 };


### PR DESCRIPTION
- Load now refreshes x tick format via xtickformat parameter.
- Add JetBrains project dir and grunt files to .gitignore.

This should resolve #1223 and #1258.
