### PR TITLE
Add .scss source files to bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "bower_components",
     "htdocs",
     "spec",
-    "src",
+    "src/**/*.js",
     "package.json",
     "component.json",
     "Gruntfile.*"


### PR DESCRIPTION
Hi !
It can be useful to have access to .scss files in the bower package for some cases.
As an exemple, it can simplify a gulp / grunt / brunch task handling styles when all the bower components of the project expose their .scss source files.
Regards.
