### PR TITLE
Added api axis.cullingMax

### DIFF
--- a/spec/api.axis-spec.js
+++ b/spec/api.axis-spec.js
@@ -51,4 +51,28 @@ describe('c3 api axis', function () {
         });
 
     });
+
+	describe('axis.cullingMax',function(){
+		it('should set max culling',function(){
+
+			chart.axis.cullingMax(2);
+			var tickCount = 0;
+			var ticks = document.querySelector('.c3-axis').querySelectorAll('.c3-axis-x .tick ');
+			
+			for(var i=0;i<ticks.length;i++){
+				var tickText = ticks[i].querySelector('text');
+				if(tickText && tickText.style){
+					if(tickText.style.display === 'block'){
+						tickCount++;
+					}
+				}
+			}
+			expect(tickCount).toBe(2);
+		});
+
+		it('should return max culling',function(){
+			chart.axis.cullingMax(1);
+			expect(chart.axis.cullingMax()).toBe(1);
+		});
+	});
 });

--- a/src/api.axis.js
+++ b/src/api.axis.js
@@ -58,3 +58,21 @@ c3_chart_fn.axis.range = function (range) {
         };
     }
 };
+
+c3_chart_fn.axis.cullingMax = function(max){
+    var $$ = this.internal, config = $$.config;
+	if(arguments.length){
+		if(isValue(max)){
+			config.axis_x_tick_culling_max = max;
+			$$.redraw({
+				withUpdateXAxis:true,            
+                withY: false,
+                withSubchart: false,
+                withEventRect: false,
+                withTransitionForAxis: false
+			});
+		}
+	}else{
+		return config.axis_x_tick_culling_max;
+	}
+};


### PR DESCRIPTION
Added new api axis.cullingMax to update the max tick culling value after chart is loaded. This pull request fixes #1356.
