### PR TITLE
use the right data index to generate y-coord for selectPoint

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -5,12 +5,12 @@ c3_chart_internal_fn.selectPoint = function (target, d, i) {
         r = $$.pointSelectR.bind($$);
     config.data_onselected.call($$.api, d, target.node());
     // add selected-circle on low layer g
-    $$.main.select('.' + CLASS.selectedCircles + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.selectedCircle + '-' + i)
+    $$.main.select('.' + CLASS.selectedCircles + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.selectedCircle + '-' + d.index)
         .data([d])
         .enter().append('circle')
         .attr("class", function () { return $$.generateClass(CLASS.selectedCircle, i); })
         .attr("cx", cx)
-        .attr("cy", cy)
+        .attr("cy", function(d){return cy(d, d.index);})
         .attr("stroke", function () { return $$.color(d); })
         .attr("r", function (d) { return $$.pointSelectR(d) * 1.4; })
         .transition().duration(100)
@@ -20,7 +20,7 @@ c3_chart_internal_fn.unselectPoint = function (target, d, i) {
     var $$ = this;
     $$.config.data_onunselected.call($$.api, d, target.node());
     // remove selected-circle from low layer g
-    $$.main.select('.' + CLASS.selectedCircles + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.selectedCircle + '-' + i)
+    $$.main.select('.' + CLASS.selectedCircles + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.selectedCircle + '-' + d.index)
         .transition().duration(100).attr('r', 0)
         .remove();
 };

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,4 +1,4 @@
-c3_chart_internal_fn.selectPoint = function (target, d, i) {
+c3_chart_internal_fn.selectPoint = function (target, d) {
     var $$ = this, config = $$.config,
         cx = (config.axis_rotated ? $$.circleY : $$.circleX).bind($$),
         cy = (config.axis_rotated ? $$.circleX : $$.circleY).bind($$),
@@ -8,7 +8,7 @@ c3_chart_internal_fn.selectPoint = function (target, d, i) {
     $$.main.select('.' + CLASS.selectedCircles + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.selectedCircle + '-' + d.index)
         .data([d])
         .enter().append('circle')
-        .attr("class", function () { return $$.generateClass(CLASS.selectedCircle, i); })
+        .attr("class", function () { return $$.generateClass(CLASS.selectedCircle, d.index); })
         .attr("cx", cx)
         .attr("cy", function(d){return cy(d, d.index);})
         .attr("stroke", function () { return $$.color(d); })
@@ -16,7 +16,7 @@ c3_chart_internal_fn.selectPoint = function (target, d, i) {
         .transition().duration(100)
         .attr("r", r);
 };
-c3_chart_internal_fn.unselectPoint = function (target, d, i) {
+c3_chart_internal_fn.unselectPoint = function (target, d) {
     var $$ = this;
     $$.config.data_onunselected.call($$.api, d, target.node());
     // remove selected-circle from low layer g
@@ -24,8 +24,8 @@ c3_chart_internal_fn.unselectPoint = function (target, d, i) {
         .transition().duration(100).attr('r', 0)
         .remove();
 };
-c3_chart_internal_fn.togglePoint = function (selected, target, d, i) {
-    selected ? this.selectPoint(target, d, i) : this.unselectPoint(target, d, i);
+c3_chart_internal_fn.togglePoint = function (selected, target, d) {
+    selected ? this.selectPoint(target, d) : this.unselectPoint(target, d);
 };
 c3_chart_internal_fn.selectPath = function (target, d) {
     var $$ = this;


### PR DESCRIPTION
Fix for existing issue 1038. Selection points for the stacked area chart seem to be missing the y-offset

Bug can be observed at http://jsfiddle.net/inabramova/9ro1vt0w/

Proposing the fix seen on http://jsfiddle.net/inabramova/tt91xs2e/
