### PR TITLE
Updated grunt jasmine to use the CDN version of D3. Fixes #1425.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -92,7 +92,7 @@ module.exports = (grunt) ->
               specs: 'spec/*-spec.js'
               helpers: 'spec/*-helper.js'
               styles: 'c3.css'
-              vendor: 'https://rawgit.com/mbostock/d3/v3.5.0/d3.min.js'
+              vendor: 'https://cdn.rawgit.com/mbostock/d3/v3.5.0/d3.min.js'
 
         uglify:
           c3:


### PR DESCRIPTION
This should definitely use the CDN version; it's possible tests are failing due to hitting the usage limit. See #1425.
