### PR TITLE
axis.x.clip option for clipping x axis by grid area.

### DIFF
--- a/src/clip.js
+++ b/src/clip.js
@@ -6,9 +6,14 @@ c3_chart_internal_fn.appendClip = function (parent, id) {
     return parent.append("clipPath").attr("id", id).append("rect");
 };
 c3_chart_internal_fn.getAxisClipX = function (forHorizontal) {
+    var $$ = this;
     // axis line width + padding for left
     var left = Math.max(30, this.margin.left);
-    return forHorizontal ? -(1 + left) : -(left - 1);
+    if (forHorizontal) {
+        return $$.config.axis_x_clip ? 0 : -(1 + left);
+    } else {
+        return -(left - 1);
+    }
 };
 c3_chart_internal_fn.getAxisClipY = function (forHorizontal) {
     return forHorizontal ? -20 : -this.margin.top;
@@ -34,7 +39,11 @@ c3_chart_internal_fn.getAxisClipWidth = function (forHorizontal) {
         left = Math.max(30, $$.margin.left),
         right = Math.max(30, $$.margin.right);
     // width + axis line width + padding for left/right
-    return forHorizontal ? $$.width + 2 + left + right : $$.margin.left + 20;
+    if (forHorizontal) {
+        return $$.config.axis_x_clip ? $$.width : $$.width + 2 + left + right;
+    } else {
+        return $$.margin.left + 20;
+    }
 };
 c3_chart_internal_fn.getAxisClipHeight = function (forHorizontal) {
     // less than 20 is not enough to show the axis label 'outer' without legend

--- a/src/config.js
+++ b/src/config.js
@@ -89,6 +89,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         // axis
         axis_rotated: false,
         axis_x_show: true,
+        axis_x_clip: false,
         axis_x_type: 'indexed',
         axis_x_localtime: true,
         axis_x_categories: [],


### PR DESCRIPTION
In some cases user may be wanted to hide x axis ticks when they leave grid area while zooming or range selection.

axis.x.clip = false
![x_axis_without_clip](https://cloud.githubusercontent.com/assets/1423028/11089461/f9ade4ca-887a-11e5-83b9-bf0838df7061.png)

axis.x.clip = true
![x_axis_with_clip](https://cloud.githubusercontent.com/assets/1423028/11089460/f9a6dd9c-887a-11e5-907b-f8758e254cc0.png)
