### PR TITLE
extracted out of mainline: patch for #1465

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -3342,11 +3342,13 @@
         };
     };
     c3_chart_internal_fn.isWithinBar = function (that) {
-        var mouse = this.d3.mouse(that), box = that.getBoundingClientRect(),
-            seg0 = that.pathSegList.getItem(0), seg1 = that.pathSegList.getItem(1),
-            x = Math.min(seg0.x, seg1.x), y = Math.min(seg0.y, seg1.y),
-            w = box.width, h = box.height, offset = 2,
-            sx = x - offset, ex = x + w + offset, sy = y + h + offset, ey = y - offset;
+        var mouse = this.d3.mouse(that),
+            box = getPathBox(that), 
+            offset = 2,
+            sx = box.x - offset, 
+            ex = box.x + box.width + offset, 
+            sy = box.y + box.height + offset, 
+            ey = box.y - offset;
         return sx < mouse[0] && mouse[0] < ex && ey < mouse[1] && mouse[1] < sy;
     };
 
@@ -6039,9 +6041,24 @@
         },
         getPathBox = c3_chart_internal_fn.getPathBox = function (path) {
             var box = path.getBoundingClientRect(),
-                items = [path.pathSegList.getItem(0), path.pathSegList.getItem(1)],
-                minX = items[0].x, minY = Math.min(items[0].y, items[1].y);
-            return {x: minX, y: minY, width: box.width, height: box.height};
+                minX, minY;
+            // MSIE supports pathSEgList while it crashes on latest Chrome: https://msdn.microsoft.com/en-us/library/ff971976(v=vs.85).aspx
+            // See also: https://github.com/masayuki0812/c3/issues/1465
+            if (path.pathSegList && path.pathSegList.getItem) {
+                var seg0 = path.pathSegList.getItem(0);
+                var seg1 = path.pathSegList.getItem(1);
+                minX = Math.min(seg0.x, seg1.x); 
+                minY = Math.min(seg0.y, seg1.y);
+            } else {
+                minX = box.left;
+                minY = box.top;
+            }
+            return {
+                x: minX, 
+                y: minY, 
+                width: box.width, 
+                height: box.height
+            };
         };
 
     c3_chart_fn.focus = function (targetIds) {

--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -113,10 +113,12 @@ c3_chart_internal_fn.generateGetBarPoints = function (barIndices, isSub) {
     };
 };
 c3_chart_internal_fn.isWithinBar = function (that) {
-    var mouse = this.d3.mouse(that), box = that.getBoundingClientRect(),
-        seg0 = that.pathSegList.getItem(0), seg1 = that.pathSegList.getItem(1),
-        x = Math.min(seg0.x, seg1.x), y = Math.min(seg0.y, seg1.y),
-        w = box.width, h = box.height, offset = 2,
-        sx = x - offset, ex = x + w + offset, sy = y + h + offset, ey = y - offset;
+    var mouse = this.d3.mouse(that),
+        box = getPathBox(that), 
+        offset = 2,
+        sx = box.x - offset, 
+        ex = box.x + box.width + offset, 
+        sy = box.y + box.height + offset, 
+        ey = box.y - offset;
     return sx < mouse[0] && mouse[0] < ex && ey < mouse[1] && mouse[1] < sy;
 };

--- a/src/util.js
+++ b/src/util.js
@@ -40,7 +40,22 @@ var isValue = c3_chart_internal_fn.isValue = function (v) {
     },
     getPathBox = c3_chart_internal_fn.getPathBox = function (path) {
         var box = path.getBoundingClientRect(),
-            items = [path.pathSegList.getItem(0), path.pathSegList.getItem(1)],
-            minX = items[0].x, minY = Math.min(items[0].y, items[1].y);
-        return {x: minX, y: minY, width: box.width, height: box.height};
+            minX, minY;
+        // MSIE supports pathSegList while it crashes on latest Chrome: https://msdn.microsoft.com/en-us/library/ff971976(v=vs.85).aspx
+        // See also: https://github.com/masayuki0812/c3/issues/1465
+        if (path.pathSegList && path.pathSegList.getItem) {
+            var seg0 = path.pathSegList.getItem(0);
+            var seg1 = path.pathSegList.getItem(1);
+            minX = Math.min(seg0.x, seg1.x); 
+            minY = Math.min(seg0.y, seg1.y);
+        } else {
+            minX = box.left;
+            minY = box.top;
+        }
+        return {
+            x: minX, 
+            y: minY, 
+            width: box.width, 
+            height: box.height
+        };
     };


### PR DESCRIPTION
origin: commit SHA-1: b7ed4407467fba164d87127ec5e31ef4d20e28d6
- fix crash in click handler due to use of pathSegList property which is not available apparently in Chrome at least: now the code is cleaned up by using the internal `getPathBox()` function, where the code is corrected to cope with this issue by taking the coordinates straight off the calculated SVG box.

_Notes_ See also: https://github.com/masayuki0812/c3/issues/1465 (#1465)
