### PR TITLE
add configurable extraspace between legend items

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -4063,7 +4063,7 @@
     c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
         var $$ = this, config = $$.config;
         var xForLegend, xForLegendText, xForLegendRect, yForLegend, yForLegendText, yForLegendRect, x1ForLegendTile, x2ForLegendTile, yForLegendTile;
-        var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5, extraspace = config.legend_item_extraspace;
+        var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5;
         var l, totalLength = 0, offsets = {}, widths = {}, heights = {}, margins = [0], steps = {}, step = 0;
         var withTransition, withTransitionForTransform;
         var texts, rects, tiles, background;

--- a/c3.js
+++ b/c3.js
@@ -1153,6 +1153,7 @@
             legend_padding: 0,
             legend_item_tile_width: 10,
             legend_item_tile_height: 10,
+            legend_item_extraspace: 0,
             // axis
             axis_rotated: false,
             axis_x_show: true,
@@ -4062,7 +4063,7 @@
     c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
         var $$ = this, config = $$.config;
         var xForLegend, xForLegendText, xForLegendRect, yForLegend, yForLegendText, yForLegendRect, x1ForLegendTile, x2ForLegendTile, yForLegendTile;
-        var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5;
+        var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5, extraspace = config.legend_item_extraspace;
         var l, totalLength = 0, offsets = {}, widths = {}, heights = {}, margins = [0], steps = {}, step = 0;
         var withTransition, withTransitionForTransform;
         var texts, rects, tiles, background;
@@ -4086,8 +4087,8 @@
         function updatePositions(textElement, id, index) {
             var reset = index === 0, isLast = index === targetIds.length - 1,
                 box = getTextBox(textElement, id),
-                itemWidth = box.width + tileWidth + (isLast && !($$.isLegendRight || $$.isLegendInset) ? 0 : paddingRight) + config.legend_padding,
-                itemHeight = box.height + paddingTop,
+                itemWidth = box.width + tileWidth + config.legend_padding + (!($$.isLegendRight || $$.isLegendInset) ? (isLast ? 0 : paddingRight + config.legend_item_extraspace) : paddingRight),
+                itemHeight = box.height + paddingTop + ((!isLast && $$.isLegendRight) ? config.legend_item_extraspace : 0),
                 itemLength = $$.isLegendRight || $$.isLegendInset ? itemHeight : itemWidth,
                 areaLength = $$.isLegendRight || $$.isLegendInset ? $$.getLegendHeight() : $$.getLegendWidth(),
                 margin, maxLength;

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -297,7 +297,7 @@ describe('c3 chart legend', function () {
         it('renders the correct distance between right legend elements', function () {
             var expectedWidth = 55,
                 expectedHeight = 33;
-            d3.selectAll('.c3-legend-item-event').each(function (d, i) {
+            d3.selectAll('.c3-legend-item-event').each(function () {
                 var rect = d3.select(this).node().getBoundingClientRect();
                 expect(rect.width).toBeCloseTo(expectedWidth, -2);
                 expect(rect.height).toBeCloseTo(expectedHeight, -2);
@@ -327,6 +327,7 @@ describe('c3 chart legend', function () {
             var expectedWidth = 55,
                 expectedHeight = 18;
             d3.selectAll('.c3-legend-item-event').each(function (d, i) {
+                expect(d).toBeDefined();
                 var rect = d3.select(this).node().getBoundingClientRect();
                 expect(rect.width).toBeCloseTo(expectedWidth + ((i === 2) ? 15 : 0), -2);
                 expect(rect.height).toBeCloseTo(expectedHeight, -2);

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -241,7 +241,7 @@ describe('c3 chart legend', function () {
         it('renders the legend item with the correct width and height', function () {
             d3.selectAll('.c3-legend-item-tile').each(function () {
                 expect(d3.select(this).style('stroke-width')).toBe(args.legend.item.tile.height + 'px');
-                var tileWidth = d3.select(this).attr('x2') - d3.select(this).attr('x1'); 
+                var tileWidth = d3.select(this).attr('x2') - d3.select(this).attr('x1');
                 expect(tileWidth).toBe(args.legend.item.tile.width);
             });
         });
@@ -267,10 +267,69 @@ describe('c3 chart legend', function () {
             d3.selectAll('.c3-legend-item-padded1 .c3-legend-item-tile, .c3-legend-item-padded2 .c3-legend-item-tile').each(function (el, index) {
                 var itemWidth = d3.select(this).node().parentNode.getBBox().width,
                     textBoxWidth = d3.select(d3.select(this).node().parentNode).select('text').node().getBBox().width,
-                    tileWidth = 15, // default value is 10, plus 5 more for padding 
+                    tileWidth = 15, // default value is 10, plus 5 more for padding
                     expectedWidth = textBoxWidth + tileWidth + (index ? 0 : 10) + args.legend.padding;
 
                 expect(itemWidth).toBe(expectedWidth);
+            });
+        });
+    });
+
+    describe('custom legend item distance', function() {
+        it('should update args', function () {
+            args = {
+                data: {
+                    columns: [
+                        ['data1', 30],
+                        ['data2', 130]
+                    ]
+                },
+                legend: {
+                    position: 'right',
+                    item: {
+                        extraspace: 15
+                    }
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('renders the correct distance between right legend elements', function () {
+            var expectedWidth = 55,
+                expectedHeight = 33;
+            d3.selectAll('.c3-legend-item-event').each(function (d, i) {
+                var rect = d3.select(this).node().getBoundingClientRect();
+                expect(rect.width).toBeCloseTo(expectedWidth, -2);
+                expect(rect.height).toBeCloseTo(expectedHeight, -2);
+            });
+        });
+
+        it('should update args', function () {
+            args = {
+                data: {
+                    columns: [
+                        ['data1', 30],
+                        ['data2', 130],
+                        ['data3', 90]
+                    ]
+                },
+                legend: {
+                    position: 'bottom',
+                    item: {
+                        extraspace: 15
+                    }
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('renders the correct distance between right legend elements', function () {
+            var expectedWidth = 55,
+                expectedHeight = 18;
+            d3.selectAll('.c3-legend-item-event').each(function (d, i) {
+                var rect = d3.select(this).node().getBoundingClientRect();
+                expect(rect.width).toBeCloseTo(expectedWidth + ((i === 2) ? 15 : 0), -2);
+                expect(rect.height).toBeCloseTo(expectedHeight, -2);
             });
         });
     });

--- a/src/config.js
+++ b/src/config.js
@@ -86,6 +86,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         legend_padding: 0,
         legend_item_tile_width: 10,
         legend_item_tile_height: 10,
+        legend_item_extraspace: 0,
         // axis
         axis_rotated: false,
         axis_x_show: true,

--- a/src/legend.js
+++ b/src/legend.js
@@ -114,7 +114,7 @@ c3_chart_internal_fn.clearLegendItemTextBoxCache = function () {
 c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
     var $$ = this, config = $$.config;
     var xForLegend, xForLegendText, xForLegendRect, yForLegend, yForLegendText, yForLegendRect, x1ForLegendTile, x2ForLegendTile, yForLegendTile;
-    var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5, extraspace = config.legend_item_extraspace;
+    var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5;
     var l, totalLength = 0, offsets = {}, widths = {}, heights = {}, margins = [0], steps = {}, step = 0;
     var withTransition, withTransitionForTransform;
     var texts, rects, tiles, background;

--- a/src/legend.js
+++ b/src/legend.js
@@ -114,7 +114,7 @@ c3_chart_internal_fn.clearLegendItemTextBoxCache = function () {
 c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
     var $$ = this, config = $$.config;
     var xForLegend, xForLegendText, xForLegendRect, yForLegend, yForLegendText, yForLegendRect, x1ForLegendTile, x2ForLegendTile, yForLegendTile;
-    var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5;
+    var paddingTop = 4, paddingRight = 10, maxWidth = 0, maxHeight = 0, posMin = 10, tileWidth = config.legend_item_tile_width + 5, extraspace = config.legend_item_extraspace;
     var l, totalLength = 0, offsets = {}, widths = {}, heights = {}, margins = [0], steps = {}, step = 0;
     var withTransition, withTransitionForTransform;
     var texts, rects, tiles, background;
@@ -138,8 +138,8 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
     function updatePositions(textElement, id, index) {
         var reset = index === 0, isLast = index === targetIds.length - 1,
             box = getTextBox(textElement, id),
-            itemWidth = box.width + tileWidth + (isLast && !($$.isLegendRight || $$.isLegendInset) ? 0 : paddingRight) + config.legend_padding,
-            itemHeight = box.height + paddingTop,
+            itemWidth = box.width + tileWidth + config.legend_padding + (!($$.isLegendRight || $$.isLegendInset) ? (isLast ? 0 : paddingRight + config.legend_item_extraspace) : paddingRight),
+            itemHeight = box.height + paddingTop + ((!isLast && $$.isLegendRight) ? config.legend_item_extraspace : 0),
             itemLength = $$.isLegendRight || $$.isLegendInset ? itemHeight : itemWidth,
             areaLength = $$.isLegendRight || $$.isLegendInset ? $$.getLegendHeight() : $$.getLegendWidth(),
             margin, maxLength;


### PR DESCRIPTION
Hi!

I created a new configurable option in order to be able to add space between legend items.

I implemented it due to a user need on touchscreen, to avoid missclicks on chart legend items.

Customizable with a config (legend.item.extraspace by default 0).
With unit tests on legend-spec.

If you have some questions or requirements,
I hope you will apply this pull request,

Regards,

mbr
