### PR TITLE
Keep the original index after a xSort

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -2179,8 +2179,13 @@
         // finish targets
         targets.forEach(function (t) {
             var i;
+            var j=0;
             // sort values by its x
             if (config.data_xSort) {
+                //Keep original index 
+                t.values.forEach(function(v){
+                    v.ori_index=j++;
+                })
                 t.values = t.values.sort(function (v1, v2) {
                     var x1 = v1.x || v1.x === 0 ? v1.x : Infinity,
                         x2 = v2.x || v2.x === 0 ? v2.x : Infinity;
@@ -3870,7 +3875,11 @@
                 text = "<table class='" + $$.CLASS.tooltip + "'>" + (title || title === 0 ? "<tr><th colspan='2'>" + title + "</th></tr>" : "");
             }
 
-            value = valueFormat(d[i].value, d[i].ratio, d[i].id, d[i].index);
+            //check if original index exist
+            if (d[i].ori_index)
+                value = valueFormat(d[i].value, d[i].ratio, d[i].id, d[i].index, d[i].ori_index)
+            else
+                value = valueFormat(d[i].value, d[i].ratio, d[i].id, d[i].index);
             if (value !== undefined) {
                 // Skip elements when their name is set to null
                 if (d[i].name === null) { continue; }


### PR DESCRIPTION
Keep the original index after a xSort, and add it to be the fifth parameter of tooltip format values:
tooltip: {
  format: {
    value: function(value,ratio,id,index,ori_index){
      return value;
    }
  }
}

Use case: Let's say X-axis is made of multiple variables. Ex. 'a+b'. We want to break down the data point on hover to show value of 'a' and 'b' too. We can't use the index, since it is changed after xSort, that's where 'ori_index' come into the picture.
