### PR TITLE
New legend position options: "left" and "top"

### DIFF
--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -140,6 +140,59 @@ describe('c3 chart legend', function () {
 
     });
 
+    describe('legend as top', function () {
+
+        it('should change the legend to "top" successfully', function () {
+            args = {
+                data: {
+                    columns: [
+                        ['data1', 30, 200, 100, 400, 150, 250],
+                        ['data2', 50, 20, 10, 40, 15, 25]
+                    ]
+                },
+                legend: {
+                    position: 'top'
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('should be located on the center of chart', function () {
+            var box = chart.internal.legend.node().getBoundingClientRect();
+            expect(box.left + box.right).toBe(640);
+        });
+
+        it('should be located on the top of chart', function () {
+            var box = chart.internal.legend.node().getBoundingClientRect();
+            expect(box.top).toBeCloseTo(0, -1);
+        });
+
+    });
+
+    describe('legend as left', function () {
+
+        it('should change the legend to "left" successfully', function () {
+            args = {
+                data: {
+                    columns: [
+                        ['data1', 30, 200, 100, 400, 150, 250],
+                        ['data2', 50, 20, 10, 40, 15, 25]
+                    ]
+                },
+                legend: {
+                    position: 'left'
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('should be located on the left of chart', function () {
+            var box = chart.internal.legend.node().getBoundingClientRect();
+            expect(box.left).toBe(10);
+        });
+
+    });
+
     describe('legend.hide', function () {
 
         it('should update args', function () {

--- a/src/core.js
+++ b/src/core.js
@@ -147,8 +147,10 @@ c3_chart_internal_fn.initParams = function () {
 
     $$.isLegendRight = config.legend_position === 'right';
     $$.isLegendInset = config.legend_position === 'inset';
-    $$.isLegendTop = config.legend_inset_anchor === 'top-left' || config.legend_inset_anchor === 'top-right';
-    $$.isLegendLeft = config.legend_inset_anchor === 'top-left' || config.legend_inset_anchor === 'bottom-left';
+    $$.isLegendTop = config.legend_position === 'top';
+    $$.isLegendLeft = config.legend_position === 'left';
+    $$.isLegendInsetTop = config.legend_inset_anchor === 'top-left' || config.legend_inset_anchor === 'top-right';
+    $$.isLegendInsetLeft = config.legend_inset_anchor === 'top-left' || config.legend_inset_anchor === 'bottom-left';
     $$.legendStep = 0;
     $$.legendItemWidth = 0;
     $$.legendItemHeight = 0;
@@ -363,7 +365,8 @@ c3_chart_internal_fn.updateSizes = function () {
     var $$ = this, config = $$.config;
     var legendHeight = $$.legend ? $$.getLegendHeight() : 0,
         legendWidth = $$.legend ? $$.getLegendWidth() : 0,
-        legendHeightForBottom = $$.isLegendRight || $$.isLegendInset ? 0 : legendHeight,
+        legendHeightForBottom = $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset || $$.isLegendTop ? 0 : legendHeight,
+        legendHeightForTop = $$.isLegendTop ? legendHeight : 0,
         hasArc = $$.hasArcType(),
         xAxisHeight = config.axis_rotated || hasArc ? 0 : $$.getHorizontalAxisHeight('x'),
         subchartHeight = config.subchart_show && !hasArc ? (config.subchart_size_height + xAxisHeight) : 0;
@@ -373,15 +376,15 @@ c3_chart_internal_fn.updateSizes = function () {
 
     // for main
     $$.margin = config.axis_rotated ? {
-        top: $$.getHorizontalAxisHeight('y2') + $$.getCurrentPaddingTop(),
+        top: $$.getHorizontalAxisHeight('y2') + $$.getCurrentPaddingTop() + legendHeightForTop,
         right: hasArc ? 0 : $$.getCurrentPaddingRight(),
         bottom: $$.getHorizontalAxisHeight('y') + legendHeightForBottom + $$.getCurrentPaddingBottom(),
-        left: subchartHeight + (hasArc ? 0 : $$.getCurrentPaddingLeft())
+        left: subchartHeight + (hasArc ? $$.isLegendLeft ? legendWidth : 0 : $$.getCurrentPaddingLeft())
     } : {
-        top: 4 + $$.getCurrentPaddingTop(), // for top tick text
-        right: hasArc ? 0 : $$.getCurrentPaddingRight(),
+        top: 4 + $$.getCurrentPaddingTop() + legendHeightForTop, // for top tick text
+        right: hasArc ? $$.isLegendLeft ? 20 : 0 : $$.getCurrentPaddingRight(),
         bottom: xAxisHeight + subchartHeight + legendHeightForBottom + $$.getCurrentPaddingBottom(),
-        left: hasArc ? 0 : $$.getCurrentPaddingLeft()
+        left: hasArc ? $$.isLegendLeft ? legendWidth + 5 : 0 : $$.getCurrentPaddingLeft()
     };
 
     // for subchart
@@ -389,7 +392,7 @@ c3_chart_internal_fn.updateSizes = function () {
         top: $$.margin.top,
         right: NaN,
         bottom: 20 + legendHeightForBottom,
-        left: $$.rotated_padding_left
+        left: $$.rotated_padding_left + ($$.isLegendLeft ? $$.getLegendWidth() + 20 : 0)
     } : {
         top: $$.currentHeight - subchartHeight - legendHeightForBottom,
         right: NaN,
@@ -411,14 +414,14 @@ c3_chart_internal_fn.updateSizes = function () {
     if ($$.width < 0) { $$.width = 0; }
     if ($$.height < 0) { $$.height = 0; }
 
-    $$.width2 = config.axis_rotated ? $$.margin.left - $$.rotated_padding_left - $$.rotated_padding_right : $$.width;
+    $$.width2 = config.axis_rotated ? $$.margin.left - $$.margin2.left - $$.rotated_padding_right : $$.width;
     $$.height2 = config.axis_rotated ? $$.height : $$.currentHeight - $$.margin2.top - $$.margin2.bottom;
     if ($$.width2 < 0) { $$.width2 = 0; }
     if ($$.height2 < 0) { $$.height2 = 0; }
 
     // for arc
-    $$.arcWidth = $$.width - ($$.isLegendRight ? legendWidth + 10 : 0);
-    $$.arcHeight = $$.height - ($$.isLegendRight ? 0 : 10);
+    $$.arcWidth = $$.width - ($$.isLegendRight ? legendWidth + 10 : $$.isLegendLeft ? 10 : 0);
+    $$.arcHeight = $$.height - ($$.isLegendRight || $$.isLegendLeft ? 0 : 10);
     if ($$.hasType('gauge') && !config.gauge_fullCircle) {
         $$.arcHeight += $$.height - $$.getGaugeLabelHeight();
     }

--- a/src/legend.js
+++ b/src/legend.js
@@ -18,15 +18,15 @@ c3_chart_internal_fn.updateLegendWithDefaults = function () {
 };
 c3_chart_internal_fn.updateSizeForLegend = function (legendHeight, legendWidth) {
     var $$ = this, config = $$.config, insetLegendPosition = {
-        top: $$.isLegendTop ? $$.getCurrentPaddingTop() + config.legend_inset_y + 5.5 : $$.currentHeight - legendHeight - $$.getCurrentPaddingBottom() - config.legend_inset_y,
-        left: $$.isLegendLeft ? $$.getCurrentPaddingLeft() + config.legend_inset_x + 0.5 : $$.currentWidth - legendWidth - $$.getCurrentPaddingRight() - config.legend_inset_x + 0.5
+        top: $$.isLegendInsetTop ? $$.getCurrentPaddingTop() + config.legend_inset_y + 5.5 : $$.currentHeight - legendHeight - $$.getCurrentPaddingBottom() - config.legend_inset_y,
+        left: $$.isLegendInsetLeft ? $$.getCurrentPaddingLeft() + config.legend_inset_x + 0.5 : $$.currentWidth - legendWidth - $$.getCurrentPaddingRight() - config.legend_inset_x + 0.5
     };
 
     $$.margin3 = {
-        top: $$.isLegendRight ? 0 : $$.isLegendInset ? insetLegendPosition.top : $$.currentHeight - legendHeight,
+        top: $$.isLegendRight || $$.isLegendLeft ? 0 : $$.isLegendInset || $$.isLegendTop ? insetLegendPosition.top : $$.currentHeight - legendHeight,
         right: NaN,
         bottom: 0,
-        left: $$.isLegendRight ? $$.currentWidth - legendWidth : $$.isLegendInset ? insetLegendPosition.left : 0
+        left: $$.isLegendRight ? $$.currentWidth - legendWidth : $$.isLegendInset ? insetLegendPosition.left : $$.isLegendLeft ? 10 : 0
     };
 };
 c3_chart_internal_fn.transformLegend = function (withTransition) {
@@ -44,12 +44,12 @@ c3_chart_internal_fn.updateLegendItemHeight = function (h) {
 };
 c3_chart_internal_fn.getLegendWidth = function () {
     var $$ = this;
-    return $$.config.legend_show ? $$.isLegendRight || $$.isLegendInset ? $$.legendItemWidth * ($$.legendStep + 1) : $$.currentWidth : 0;
+    return $$.config.legend_show ? $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? $$.legendItemWidth * ($$.legendStep + 1) : $$.currentWidth : 0;
 };
 c3_chart_internal_fn.getLegendHeight = function () {
     var $$ = this, h = 0;
     if ($$.config.legend_show) {
-        if ($$.isLegendRight) {
+        if ($$.isLegendRight || $$.isLegendLeft) {
             h = $$.currentHeight;
         } else {
             h = Math.max(20, $$.legendItemHeight) * ($$.legendStep + 1);
@@ -138,10 +138,10 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
     function updatePositions(textElement, id, index) {
         var reset = index === 0, isLast = index === targetIds.length - 1,
             box = getTextBox(textElement, id),
-            itemWidth = box.width + tileWidth + (isLast && !($$.isLegendRight || $$.isLegendInset) ? 0 : paddingRight) + config.legend_padding,
+            itemWidth = box.width + tileWidth + (isLast && !($$.isLegendRight || $$.isLegendLeft || $$.isLegendInset) ? 0 : paddingRight) + config.legend_padding,
             itemHeight = box.height + paddingTop,
-            itemLength = $$.isLegendRight || $$.isLegendInset ? itemHeight : itemWidth,
-            areaLength = $$.isLegendRight || $$.isLegendInset ? $$.getLegendHeight() : $$.getLegendWidth(),
+            itemLength = $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? itemHeight : itemWidth,
+            areaLength = $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? $$.getLegendHeight() : $$.getLegendWidth(),
             margin, maxLength;
 
         // MEMO: care about condifion of step, totalLength
@@ -177,7 +177,7 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
 
         if (!maxWidth || itemWidth >= maxWidth) { maxWidth = itemWidth; }
         if (!maxHeight || itemHeight >= maxHeight) { maxHeight = itemHeight; }
-        maxLength = $$.isLegendRight || $$.isLegendInset ? maxHeight : maxWidth;
+        maxLength = $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? maxHeight : maxWidth;
 
         if (config.legend_equally) {
             Object.keys(widths).forEach(function (id) { widths[id] = maxWidth; });
@@ -201,7 +201,7 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
         $$.updateLegendStep(step);
     }
 
-    if ($$.isLegendRight) {
+    if ($$.isLegendRight || $$.isLegendLeft) {
         xForLegend = function (id) { return maxWidth * steps[id]; };
         yForLegend = function (id) { return margins[steps[id]] + offsets[id]; };
     } else if ($$.isLegendInset) {
@@ -263,21 +263,21 @@ c3_chart_internal_fn.updateLegend = function (targetIds, options, transitions) {
         .text(function (id) { return isDefined(config.data_names[id]) ? config.data_names[id] : id; })
         .each(function (id, i) { updatePositions(this, id, i); })
         .style("pointer-events", "none")
-        .attr('x', $$.isLegendRight || $$.isLegendInset ? xForLegendText : -200)
-        .attr('y', $$.isLegendRight || $$.isLegendInset ? -200 : yForLegendText);
+        .attr('x', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? xForLegendText : -200)
+        .attr('y', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? -200 : yForLegendText);
     l.append('rect')
         .attr("class", CLASS.legendItemEvent)
         .style('fill-opacity', 0)
-        .attr('x', $$.isLegendRight || $$.isLegendInset ? xForLegendRect : -200)
-        .attr('y', $$.isLegendRight || $$.isLegendInset ? -200 : yForLegendRect);
+        .attr('x', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? xForLegendRect : -200)
+        .attr('y', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? -200 : yForLegendRect);
     l.append('line')
         .attr('class', CLASS.legendItemTile)
         .style('stroke', $$.color)
         .style("pointer-events", "none")
-        .attr('x1', $$.isLegendRight || $$.isLegendInset ? x1ForLegendTile : -200)
-        .attr('y1', $$.isLegendRight || $$.isLegendInset ? -200 : yForLegendTile)
-        .attr('x2', $$.isLegendRight || $$.isLegendInset ? x2ForLegendTile : -200)
-        .attr('y2', $$.isLegendRight || $$.isLegendInset ? -200 : yForLegendTile)
+        .attr('x1', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? x1ForLegendTile : -200)
+        .attr('y1', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? -200 : yForLegendTile)
+        .attr('x2', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? x2ForLegendTile : -200)
+        .attr('y2', $$.isLegendRight || $$.isLegendLeft || $$.isLegendInset ? -200 : yForLegendTile)
         .attr('stroke-width', config.legend_item_tile_height);
 
     // Set background for inset legend

--- a/src/size.js
+++ b/src/size.js
@@ -5,7 +5,7 @@ c3_chart_internal_fn.getCurrentWidth = function () {
 c3_chart_internal_fn.getCurrentHeight = function () {
     var $$ = this, config = $$.config,
         h = config.size_height ? config.size_height : $$.getParentHeight();
-    return h > 0 ? h : 320 / ($$.hasType('gauge') && !config.gauge_fullCircle ? 2 : 1); 
+    return h > 0 ? h : 320 / ($$.hasType('gauge') && !config.gauge_fullCircle ? 2 : 1);
 };
 c3_chart_internal_fn.getCurrentPaddingTop = function () {
     var $$ = this,
@@ -21,15 +21,15 @@ c3_chart_internal_fn.getCurrentPaddingBottom = function () {
     return isValue(config.padding_bottom) ? config.padding_bottom : 0;
 };
 c3_chart_internal_fn.getCurrentPaddingLeft = function (withoutRecompute) {
-    var $$ = this, config = $$.config;
+    var $$ = this, config = $$.config, legendWidthOnLeft = $$.isLegendLeft ? $$.getLegendWidth() + 20 : 0;
     if (isValue(config.padding_left)) {
         return config.padding_left;
     } else if (config.axis_rotated) {
-        return !config.axis_x_show ? 1 : Math.max(ceil10($$.getAxisWidthByAxisId('x', withoutRecompute)), 40);
+        return legendWidthOnLeft + (!config.axis_x_show ? 1 : Math.max(ceil10($$.getAxisWidthByAxisId('x', withoutRecompute)), 40));
     } else if (!config.axis_y_show || config.axis_y_inner) { // && !config.axis_rotated
-        return $$.axis.getYAxisLabelPosition().isOuter ? 30 : 1;
+        return legendWidthOnLeft + ($$.axis.getYAxisLabelPosition().isOuter ? 30 : 1);
     } else {
-        return ceil10($$.getAxisWidthByAxisId('y', withoutRecompute));
+        return ceil10($$.getAxisWidthByAxisId('y', withoutRecompute)) + legendWidthOnLeft;
     }
 };
 c3_chart_internal_fn.getCurrentPaddingRight = function () {
@@ -95,8 +95,8 @@ c3_chart_internal_fn.getHorizontalAxisHeight = function (axisId) {
     var $$ = this, config = $$.config, h = 30;
     if (axisId === 'x' && !config.axis_x_show) { return 8; }
     if (axisId === 'x' && config.axis_x_height) { return config.axis_x_height; }
-    if (axisId === 'y' && !config.axis_y_show) { 
-        return config.legend_show && !$$.isLegendRight && !$$.isLegendInset ? 10 : 1; 
+    if (axisId === 'y' && !config.axis_y_show) {
+        return config.legend_show && !$$.isLegendRight && !$$.isLegendLeft && !$$.isLegendInset ? 10 : 1;
     }
     if (axisId === 'y2' && !config.axis_y2_show) { return $$.rotated_padding_top; }
     // Calculate x axis height when tick rotated


### PR DESCRIPTION
#508

Hi,
In our project we need to position legend left and top so I tried to enchanch C3 for this prupose. The generated charts have the exact same height and width for `legend_position` `left` and `top` as they have for `legend_position` `right` and `bottom`, even for arcs.
We will use this anyway but we want to share all our enchanchments and hope at least some of them will be accepted :-)

![legend-left-and-right](https://cloud.githubusercontent.com/assets/11871137/12048354/9e122f3c-aeda-11e5-9843-4038003a1982.png)
