### PR TITLE
Fix flickering sorting that occurs with stacked area graphs

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -32,22 +32,9 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
         text, i, title, value, name, bgcolor,
         orderAsc = $$.isOrderAsc();
 
-    if (config.data_groups.length === 0) {
-        d.sort(function(a,b){
-            return orderAsc ? a.value - b.value : b.value - a.value;
-        });
-    } else {
-        var ids = $$.orderTargets($$.data.targets).map(function (i) {
-            return i.id;
-        });
-        d.sort(function(a, b) {
-            if (a.value > 0 && b.value > 0) {
-                return orderAsc ? ids.indexOf(a.id) - ids.indexOf(b.id) : ids.indexOf(b.id) - ids.indexOf(a.id);
-            } else {
-                return orderAsc ? a.value - b.value : b.value - a.value;
-            }
-        });
-    }
+    d.sort(function(a,b){
+        return orderAsc ? a.value - b.value : b.value - a.value;
+    });
 
     for (i = 0; i < d.length; i++) {
         if (! (d[i] && (d[i].value || d[i].value === 0))) { continue; }


### PR DESCRIPTION
Fix flickering sorting that occurs with stacked area graphs tool tips when there are series with value zero.  Also prevents arbitrary sorting that occurs in legend on clicking.  Attached is a test case.  Move the cursor up and down over one x-value and you will see the flickering in the tool tip.  Chrome 47.
[test.html.txt](https://github.com/masayuki0812/c3/files/96523/test.html.txt)
