### PR TITLE
Fixes issue of trying to flow data when there is no data to start

### DIFF
--- a/src/api.flow.js
+++ b/src/api.flow.js
@@ -202,7 +202,7 @@ c3_chart_internal_fn.generateFlow = function (args) {
                     translateX = diffDomain(domain) / 2;
                 }
             }
-        } else if (flow.orgDataCount === 1 || flowStart.x === flowEnd.x) {
+        } else if (flow.orgDataCount === 1 || (flowStart && flowStart.x) === (flowEnd && flowEnd.x)) {
             translateX = $$.x(orgDomain[0]) - $$.x(domain[0]);
         } else {
             if ($$.isTimeSeries()) {


### PR DESCRIPTION
This PR fixes issue #1235 where errors are seen in the console when trying to flow data to a chart that does not yet have any data in it. The fix merely checks that the flow start and flow end have values before checking their respective `x` properties (which resulted in a null property check otherwise).