### PR TITLE
Allow tooltip formatter to change output depending on all data points.

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -57,7 +57,7 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
             text = "<table class='" + $$.CLASS.tooltip + "'>" + (title || title === 0 ? "<tr><th colspan='2'>" + title + "</th></tr>" : "");
         }
 
-        value = valueFormat(d[i].value, d[i].ratio, d[i].id, d[i].index);
+        value = valueFormat(d[i].value, d[i].ratio, d[i].id, d[i].index, d);
         if (value !== undefined) {
             // Skip elements when their name is set to null
             if (d[i].name === null) { continue; }


### PR DESCRIPTION
I often need to adjust the values presented to the user in the tooltip. Therefore I need information about all data points being displayed for the current point in time.

BTW: I mainly need this because I cannot format the contents of a bar chart depending on its sign.