### PR TITLE
#1602 - Makes unfilled portion of full circle gauge visible. 

### DIFF
--- a/spec/arc-spec.js
+++ b/spec/arc-spec.js
@@ -151,7 +151,7 @@ describe('c3 chart arc', function () {
                     .select('g.c3-shapes.c3-shapes-data.c3-arcs.c3-arcs-data')
                     .select('path.c3-shape.c3-shape.c3-arc.c3-arc-data');
 
-            // This test has bee updated to make tests pass. @TODO double-check this test is accurate.
+            // This test has been updated to make tests pass. @TODO double-check this test is accurate.
             expect(data.attr('d')).toMatch(/M-221.*?,-2\..+A221.*?,221.*? 0 1,1 -68.*?,210.*?L-65.*?,201.*?A211.*?,211.*? 0 1,0 -211.*?,-2.*?Z/);
         });
     });


### PR DESCRIPTION
Fixes the problem with gauge where a full circle gauge does not show the portion of the gauge that is not filled (#1602).
