### PR TITLE
point.select.r can now can accept a function

### DIFF
--- a/src/shape.line.js
+++ b/src/shape.line.js
@@ -372,7 +372,7 @@ c3_chart_internal_fn.pointExpandedR = function (d) {
 };
 c3_chart_internal_fn.pointSelectR = function (d) {
     var $$ = this, config = $$.config;
-    return config.point_select_r ? config.point_select_r : $$.pointR(d) * 4;
+    return isFunction(config.point_select_r) ? config.point_select_r(d) : ((config.point_select_r) ? config.point_select_r : $$.pointR(d) * 4);
 };
 c3_chart_internal_fn.isWithinCircle = function (that, r) {
     var d3 = this.d3,


### PR DESCRIPTION
Previously, point.select.r was defined by either a single constant value or would default to 4 times the radius.  Now it can be defined by a custom function.