### PR TITLE
Add option to configure pie label ratio

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -94,7 +94,9 @@ c3_chart_internal_fn.transformForArcLabel = function (d) {
         x = isNaN(c[0]) ? 0 : c[0];
         y = isNaN(c[1]) ? 0 : c[1];
         h = Math.sqrt(x * x + y * y);
-        if (config.pie_label_ratio) {
+        if ($$.hasType('donut') && config.donut_label_ratio) {
+            ratio = isFunction(config.donut_label_ratio) ? config.donut_label_ratio(d, $$.radius, h) : config.donut_label_ratio;
+        } else if ($$.hasType('pie') && config.pie_label_ratio) {
             ratio = isFunction(config.pie_label_ratio) ? config.pie_label_ratio(d, $$.radius, h) : config.pie_label_ratio;
         } else {
             ratio = $$.radius && h ? (36 / $$.radius > 0.375 ? 1.175 - 36 / $$.radius : 0.8) * $$.radius / h : 0;

--- a/src/arc.js
+++ b/src/arc.js
@@ -87,15 +87,18 @@ c3_chart_internal_fn.getArc = function (d, withoutUpdate, force) {
 
 
 c3_chart_internal_fn.transformForArcLabel = function (d) {
-    var $$ = this,
+    var $$ = this, config = $$.config,
         updated = $$.updateAngle(d), c, x, y, h, ratio, translate = "";
     if (updated && !$$.hasType('gauge')) {
         c = this.svgArc.centroid(updated);
         x = isNaN(c[0]) ? 0 : c[0];
         y = isNaN(c[1]) ? 0 : c[1];
         h = Math.sqrt(x * x + y * y);
-        // TODO: ratio should be an option?
-        ratio = $$.radius && h ? (36 / $$.radius > 0.375 ? 1.175 - 36 / $$.radius : 0.8) * $$.radius / h : 0;
+        if (config.pie_label_ratio) {
+            ratio = isFunction(config.pie_label_ratio) ? config.pie_label_ratio(d, $$.radius, h) : config.pie_label_ratio;
+        } else {
+            ratio = $$.radius && h ? (36 / $$.radius > 0.375 ? 1.175 - 36 / $$.radius : 0.8) * $$.radius / h : 0;
+        }
         translate = "translate(" + (x * ratio) +  ',' + (y * ratio) +  ")";
     }
     return translate;

--- a/src/config.js
+++ b/src/config.js
@@ -188,6 +188,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         donut_label_show: true,
         donut_label_format: undefined,
         donut_label_threshold: 0.05,
+        donut_label_ratio: undefined,
         donut_width: undefined,
         donut_title: "",
         donut_expand: {},

--- a/src/config.js
+++ b/src/config.js
@@ -172,6 +172,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         pie_label_show: true,
         pie_label_format: undefined,
         pie_label_threshold: 0.05,
+        pie_label_ratio: undefined,
         pie_expand: {},
         pie_expand_duration: 50,
         // gauge


### PR DESCRIPTION
Keep default behaviour when no option is set
Works with a number or a function
Fixes  #1628