### PR TITLE
Fixes error that causes permanently fail of chart creation

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -5700,6 +5700,9 @@
     };
     c3_chart_internal_fn.redrawForZoom = function () {
         var $$ = this, d3 = $$.d3, config = $$.config, zoom = $$.zoom, x = $$.x;
+        if(d3.event.sourceEvent == null){
+            return;
+        }
         if (!config.zoom_enabled) {
             return;
         }


### PR DESCRIPTION
in some cases d3.event.sourceEvent is null (I don't really know why)... In my case that happens when i change thw window soze of the browser window and then zoom in charts with my infrared multitouch TV, then a exception is thrown "can't read the property of type on 'null' ". After that error is thrown (I also don't know why) its not possible to create new charts with c3.

this will fix the issue
