### PR TITLE
Fixes some tick are missing to display when chart type is category and categories array is supplied

### DIFF
--- a/src/category.js
+++ b/src/category.js
@@ -1,4 +1,4 @@
 c3_chart_internal_fn.categoryName = function (i) {
-    var config = this.config;
-    return i < config.axis_x_categories.length ? config.axis_x_categories[i] : i;
+    var config = this.config, categoryIndex = Math.ceil(i);
+    return i < config.axis_x_categories.length ? config.axis_x_categories[categoryIndex] : i;
 };


### PR DESCRIPTION
It's related to issue https://github.com/masayuki0812/c3/issues/1638;
Basically it caused by method Axis.prototype.generateTickValues and c3_chart_internal_fn.categoryName.

The tick value generated by Axis.prototype.generateTickValues, the decimal value passed in as index of array config.axis_x_categories[i], it can't get the categoryName, just return undefined.

```
 c3_chart_internal_fn.categoryName = function (i) {
        var config = this.config;
        return i < config.axis_x_categories.length ? config.axis_x_categories[i] : i;
    };
```

Fixing it by adding categoryIndex = Math.ceil(i);

c3.chart.internal.fn.categoryName = function (i) {
    var config = this.config, categoryIndex = Math.ceil(i);
    return i < config.axis_x_categories.length ? config.axis_x_categories[categoryIndex] : i;
};
If we fix it inside generateTickValues to generate integer tick value , it will cause splitTickText doesn't work properly.
From:
`tickValues.push(forTimeSeries ? new Date(tickValue) : tickValue);`
To:
`tickValues.push(forTimeSeries ? new Date(tickValue) : $$.isCategorized() ? Math.ceil(tickValue): tickValue);`
