### PR TITLE
Updated .travis.yml to do a full build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ before_script:
 - gem install sass
 
 script:
-- npm run lint
-- npm test
+- grunt
 
 after_success:
 - npm run codecov


### PR DESCRIPTION
The current Travis config won't ever pass newly-added unit tests because it doesn't do an actual build from the updated source files. This just replaces the `lint/test` lines with `grunt`, which runs linting and testing anyway.