### PR TITLE
PR isCountMax option

### DIFF
--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -836,5 +836,100 @@ describe('c3 chart axis', function () {
         });
 
     });
+    describe('tick.countIsMax', function () {
+        it('add y, y2 axises and data', function () {
+            args = {
+                data: {
+                    columns: [
+                        ['data1', 30, 33, 350, 400, 550, 750, 1000, 1300, 1700,2303],
+                        ['data2', 10, 20, 200, 204, 260, 375, 400, 1000, 1995,3100]
+                    ],
+                    axes: {
+                        data1: 'y',
+                        data2: 'y2'
+                    }
+                },
+                axis: {
+                    y: {
+                        show: true,
+                        tick: {
+                            count: 4,
+                            countIsMax: true
+                        }
+
+                    },
+                    y2: {
+                        show: true,
+                        tick: {
+                            count: 4,
+                            countIsMax: true
+                        }
+
+                    }
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        /*validating that the number of ticks is between max and 2 (minimum)*/
+        it('y axis should have not more then 4 ticks', function () {
+            var ticksSize = d3.select('.c3-axis-y').selectAll('g.tick').size();
+            expect(ticksSize > 1 && ticksSize < 5).toBeTruthy();
+        });
+
+
+        it('y2 axis should have not more then 4 ticks', function () {
+            var ticksSize = d3.select('.c3-axis-y2').selectAll('g.tick').size();
+            expect(ticksSize > 1 && ticksSize < 5).toBeTruthy();
+        });
+
+        it('build a chart with very low values to validate minimums', function () {
+
+            args = {
+                data: {
+                    columns: [
+                        ['data1', -1000, 37],
+                        ['data2', -134, 109, 432,2,65,1000]
+                    ],
+                    axes: {
+                        data1: 'y',
+                        data2: 'y2'
+                    }
+                },
+                axis: {
+                    y: {
+                        show: true,
+                        tick: {
+                            count: 1,
+                            countIsMax: true
+                        }
+
+                    },
+                    y2: {
+                        show: true,
+                        tick: {
+                            count: 2,
+                            countIsMax: true
+                        }
+
+                    }
+                }
+            };
+
+            expect(true).toBeTruthy();
+        });
+
+        /*validating the minimum allowed ticks*/
+        it('should have minimum count of 2 on y axis', function () {
+            var ticksSize = d3.select('.c3-axis-y').selectAll('g.tick').size();
+            expect(ticksSize).toBe(2);
+        });
+
+        it('should have minimum count of 2 on y2 axis', function () {
+            var ticksSize = d3.select('.c3-axis-y2').selectAll('g.tick').size();
+            expect(ticksSize).toBe(2);
+        });
+
+    });
 
 });

--- a/src/axis.js
+++ b/src/axis.js
@@ -335,6 +335,30 @@ Axis.prototype.convertPixelsToAxisPadding = function convertPixelsToAxisPadding(
         length = $$.config.axis_rotated ? $$.width : $$.height;
     return domainLength * (pixels / length);
 };
+/**
+ * Finds the closest "nicely" arranged set of y/y2 axis ticks,
+ * with count of ticks below the number specified in "maxCount"
+ * Turned on by setting axis.tick.isCountMax and axis.tick.count arguments in chart definition JSON
+ * Minimum number of ticks = 2, in case get getYDomain doesnt return 2 elements range, will build a range of first and last element
+ * Michael Rodov.
+ * @param self- chart object
+ * @param maxCount - maximum number of desired ticks, nicely arranged
+ * @param axisName - can be either y or y2 axis
+ * @returns {*} - set of nicely arranged ticks, with count lower then maxCount
+ */
+Axis.prototype.getTickValuesWithMaxTickCount = function (self, maxCount, axisName) {
+    maxCount = Math.max(2, maxCount);
+    var tickValues = self[axisName].domain(self.getYDomain(self.data.targets, axisName)).ticks(i);
+    for (var i = maxCount; tickValues.length > maxCount && i > 1; i--) {
+        tickValues = self[axisName].domain(self.getYDomain(self.data.targets, axisName)).ticks(i);
+    }
+
+    if (tickValues.length === 1 || (maxCount === 2 & tickValues.length > 2)) { //for those who only have one tick generated,
+        return [Math.min(0, tickValues[0]), Math.max(0, tickValues[tickValues.length - 1])];
+    }
+
+    return tickValues;
+};
 Axis.prototype.generateTickValues = function generateTickValues(values, tickCount, forTimeSeries) {
     var tickValues = values, targetCount, start, end, count, interval, i, tickValue;
     if (tickCount) {

--- a/src/config.js
+++ b/src/config.js
@@ -124,6 +124,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         axis_y_tick_values: null,        
         axis_y_tick_rotate: 0,
         axis_y_tick_count: undefined,
+        axis_y_tick_countIsMax: false,
         axis_y_tick_time_value: undefined,
         axis_y_tick_time_interval: undefined,
         axis_y_padding: {},
@@ -139,6 +140,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         axis_y2_tick_outer: true,
         axis_y2_tick_values: null,
         axis_y2_tick_count: undefined,
+        axis_y2_tick_countIsMax: false,
         axis_y2_padding: {},
         axis_y2_default: undefined,
         // grid

--- a/src/core.js
+++ b/src/core.js
@@ -525,13 +525,21 @@ c3_chart_internal_fn.redraw = function (options, transitions) {
     $$.y.domain($$.getYDomain(targetsToShow, 'y', xDomainForZoom));
     $$.y2.domain($$.getYDomain(targetsToShow, 'y2', xDomainForZoom));
 
+    /*Generate either nice or bruteforce calculated ticks*/
     if (!config.axis_y_tick_values && config.axis_y_tick_count) {
-        $$.yAxis.tickValues($$.axis.generateTickValues($$.y.domain(), config.axis_y_tick_count));
+        if(config.axis_y_tick_countIsMax){
+            $$.yAxis.tickValues($$.axis.getTickValuesWithMaxTickCount($$, config.axis_y_tick_count, "y"));
+        }else{
+            $$.yAxis.tickValues($$.axis.generateTickValues($$.y.domain(), config.axis_y_tick_count));
+        }
     }
     if (!config.axis_y2_tick_values && config.axis_y2_tick_count) {
-        $$.y2Axis.tickValues($$.axis.generateTickValues($$.y2.domain(), config.axis_y2_tick_count));
+        if(config.axis_y2_tick_countIsMax) {
+            $$.y2Axis.tickValues($$.axis.getTickValuesWithMaxTickCount($$, config.axis_y2_tick_count, "y2"));
+        }else{
+            $$.y2Axis.tickValues($$.axis.generateTickValues($$.y2.domain(), config.axis_y2_tick_count));
+        }
     }
-
     // axes
     $$.axis.redraw(transitions, hideAxis);
 


### PR DESCRIPTION
Finds the closest "nicely" arranged set of y/y2 axis ticks,
 * with count of ticks below the number specified in "maxCount"
 * Turned on by setting axis.tick.isCountMax and axis.tick.count arguments in chart definition JSON
 * Minimum number of ticks = 2, in case get getYDomain doesnt return 2 elements range, will build a range of first and last element
 * Michael Rodov.