### PR TITLE
Coerced width and height config values to int

### DIFF
--- a/src/size.js
+++ b/src/size.js
@@ -1,10 +1,10 @@
 c3_chart_internal_fn.getCurrentWidth = function () {
     var $$ = this, config = $$.config;
-    return config.size_width ? config.size_width : $$.getParentWidth();
+    return config.size_width ? parseInt(config.size_width) : $$.getParentWidth();
 };
 c3_chart_internal_fn.getCurrentHeight = function () {
     var $$ = this, config = $$.config,
-        h = config.size_height ? config.size_height : $$.getParentHeight();
+        h = config.size_height ? parseInt(config.size_height) : $$.getParentHeight();
     return h > 0 ? h : 320 / ($$.hasType('gauge') && !config.gauge_fullCircle ? 2 : 1); 
 };
 c3_chart_internal_fn.getCurrentPaddingTop = function () {


### PR DESCRIPTION
I've spent a day figuring out why tooltip isn't showing. 
In `c3_chart_internal_fn.tooltipPosition` I got 

```
chartRight = svgLeft + $$.currentWidth - $$.getCurrentPaddingRight();
```

with following values:

```
svgLeft = 0.5
$$.currentWidth = "800"
```

so I got chartRight around `"0.5800"`.
The problem that I set width from HTML attribute as string. I think it worth nothing to cast them to int, it could saves anyone's time.
