### PR TITLE
added check for null in c3_chart_internal_fn.expandArc

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -143,7 +143,7 @@ c3_chart_internal_fn.expandArc = function (targetIds) {
         interval = window.setInterval(function () {
             if (!$$.transiting) {
                 window.clearInterval(interval);
-                if ($$.legend.selectAll('.c3-legend-item-focused').size() > 0) {
+                if ($$.legend && $$.legend.selectAll('.c3-legend-item-focused').size() > 0) {
                     $$.expandArc(targetIds);
                 }
             }


### PR DESCRIPTION
fixes error when chart is destroyed before it finishes rendering
