### PR TITLE
Cull x axis ticks via css for more flexibility

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -547,14 +547,14 @@ c3_chart_internal_fn.redraw = function (options, transitions) {
                     break;
                 }
             }
-            $$.svg.selectAll('.' + CLASS.axisX + ' .tick text').each(function (e) {
+            $$.svg.selectAll('.' + CLASS.axisX + ' .tick').each(function (e) {
                 var index = tickValues.indexOf(e);
                 if (index >= 0) {
-                    d3.select(this).style('display', index % intervalForCulling ? 'none' : 'block');
+                    d3.select(this).classed('culled', index % intervalForCulling);
                 }
             });
         } else {
-            $$.svg.selectAll('.' + CLASS.axisX + ' .tick text').style('display', 'block');
+            $$.svg.selectAll('.' + CLASS.axisX + ' .tick').classed('culled', false);
         }
     }
 

--- a/src/scss/axis.scss
+++ b/src/scss/axis.scss
@@ -1,4 +1,7 @@
 .c3-axis-x .tick {
+  &.culled text {
+    display: none;
+  }
 }
 .c3-axis-x-label {
 }


### PR DESCRIPTION
With this pull request and by adding your own css, you can go from the current enforced choice:

![screen shot 2016-06-15 at 2 20 44 pm](https://cloud.githubusercontent.com/assets/395678/16093851/9bfaf6d8-330b-11e6-882d-a116e74548a4.png)

to something as random as this:

![screen shot 2016-06-15 at 2 40 17 pm](https://cloud.githubusercontent.com/assets/395678/16093852/9bfd9ec4-330b-11e6-8aa3-6178ddf75b07.png)

But most importantly, you can hide the culled tick marks:
![screen shot 2016-06-15 at 10 25 55 pm](https://cloud.githubusercontent.com/assets/395678/16103642/3dc54a2c-3348-11e6-981a-1a7c60d39cec.png)
