### PR TITLE
Culling to consider zoomed-in range rather than the whole range - implementing #1280

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -546,8 +546,16 @@
         // show/hide if manual culling needed
         if ((withUpdateXDomain || withUpdateXAxis) && targetsToShow.length) {
             if (config.axis_x_tick_culling && tickValues) {
-                for (i = 1; i < tickValues.length; i++) {
-                    if (tickValues.length / i < config.axis_x_tick_culling_max) {
+                var cullSet = tickValues;
+                if (config.zoom_rescale && !options.flow && xDomainForZoom && xDomainForZoom.length===2) {
+                    cullSet = [];
+                    for (i = 1; i < tickValues.length; i++) {
+                        if (tickValues[i]<xDomainForZoom[0] || tickValues[i]>xDomainForZoom[1]) continue;
+                        cullSet.push(tickValues[i]);
+                    }
+                }
+                for (i = 1; i < cullSet.length; i++) {
+                    if (cullSet.length / i < config.axis_x_tick_culling_max) {
                         intervalForCulling = i;
                         break;
                     }

--- a/c3.js
+++ b/c3.js
@@ -546,16 +546,17 @@
         // show/hide if manual culling needed
         if ((withUpdateXDomain || withUpdateXAxis) && targetsToShow.length) {
             if (config.axis_x_tick_culling && tickValues) {
-                var cullSet = tickValues;
+                var cullSetLength = tickValues.length;
                 if (config.zoom_rescale && !options.flow && xDomainForZoom && xDomainForZoom.length===2) {
-                    cullSet = [];
+                    cullSetLength = 0;
                     for (i = 1; i < tickValues.length; i++) {
                         if (tickValues[i]<xDomainForZoom[0] || tickValues[i]>xDomainForZoom[1]) continue;
-                        cullSet.push(tickValues[i]);
+                        cullSetLength++;
                     }
                 }
-                for (i = 1; i < cullSet.length; i++) {
-                    if (cullSet.length / i < config.axis_x_tick_culling_max) {
+
+                for (i = 1; i < cullSetLength; i++) {
+                    if (cullSetLength / i < config.axis_x_tick_culling_max) {
                         intervalForCulling = i;
                         break;
                     }

--- a/c3.js
+++ b/c3.js
@@ -550,7 +550,10 @@
                 if (config.zoom_rescale && !options.flow && xDomainForZoom && xDomainForZoom.length===2) {
                     cullSetLength = 0;
                     for (i = 1; i < tickValues.length; i++) {
-                        if (tickValues[i]<xDomainForZoom[0] || tickValues[i]>xDomainForZoom[1]) continue;
+                        if (tickValues[i]<xDomainForZoom[0] || tickValues[i]>xDomainForZoom[1]) {
+                            continue;
+                        }
+
                         cullSetLength++;
                     }
                 }


### PR DESCRIPTION
**#1280  Change culling after zooming** is needed for my use case, so here I am implementing it. Hope it helps!

Update: I've committed a better version, calculating `cullSetLength` instead of generating actual `cullSet` — saving array memory allocation.
