### PR TITLE
Call onhide on each tooltip hide

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -133,4 +133,5 @@ c3_chart_internal_fn.showTooltip = function (selectedData, element) {
 };
 c3_chart_internal_fn.hideTooltip = function () {
     this.tooltip.style("display", "none");
+    this.config.tooltip_onhide.call(this);
 };


### PR DESCRIPTION
The onhide method of the tooltip api is only called when the tooltip is closed from the api.
This PR call this methods when the tooltip is closed from the api or from an internal reason.