### PR TITLE
Changes all stubbed assertions to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_script:
 script:
 - grunt
 
-after_success:
-- npm run codecov
+after_script:
+- npm run coverage
 
 notifications:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "grunt lint",
     "test": "karma start karma.conf.js",
-    "codecov": "cat coverage/*/lcov.info | codecov"
+    "coverage": "cat coverage/*/lcov.info | codecov"
   },
   "repository": {
     "type": "git",

--- a/spec/api.axis-spec.js
+++ b/spec/api.axis-spec.js
@@ -31,7 +31,7 @@ describe('c3 api axis', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should update y axis label', function () {

--- a/spec/api.focus-spec.js
+++ b/spec/api.focus-spec.js
@@ -382,7 +382,7 @@ describe('c3 api focus', function () {
             args.legend = {
                 show: false
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should focus all targets without showing legend', function (done) {

--- a/spec/api.grid-spec.js
+++ b/spec/api.grid-spec.js
@@ -17,7 +17,7 @@ describe('c3 api grid', function () {
                     ]
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should update y grids', function (done) {

--- a/spec/api.load-spec.js
+++ b/spec/api.load-spec.js
@@ -20,7 +20,7 @@ describe('c3 api load', function () {
                         ]
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should load additional data', function (done) {
@@ -62,7 +62,7 @@ describe('c3 api load', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         describe('as column', function () {

--- a/spec/api.region-spec.js
+++ b/spec/api.region-spec.js
@@ -31,7 +31,7 @@ describe('c3 api region', function () {
                     }
                 ]
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should update regions', function (done) {
@@ -106,7 +106,7 @@ describe('c3 api region', function () {
                     }
                 ]
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should add regions', function (done) {
@@ -203,7 +203,7 @@ describe('c3 api region', function () {
                     },
                 ]
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should remove regions', function (done) {

--- a/spec/api.zoom-spec.js
+++ b/spec/api.zoom-spec.js
@@ -22,7 +22,7 @@ describe('c3 api zoom', function () {
                     enabled: true
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be zoomed properly', function () {
@@ -59,7 +59,7 @@ describe('c3 api zoom', function () {
                     enabled: true
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be zoomed properly', function () {
@@ -93,7 +93,7 @@ describe('c3 api zoom', function () {
                     enabled: true
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be unzoomed properly', function () {

--- a/spec/arc-spec.js
+++ b/spec/arc-spec.js
@@ -20,7 +20,7 @@ describe('c3 chart arc', function () {
                     type: 'pie'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have correct classes', function () {
@@ -53,7 +53,7 @@ describe('c3 chart arc', function () {
                 ['data2', 150],
                 ['data3', 120]
             ];
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have correct d even if data id can be converted to a color', function (done) {
@@ -74,7 +74,7 @@ describe('c3 chart arc', function () {
                     type: 'pie'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have correct d attribute', function () {
@@ -113,7 +113,7 @@ describe('c3 chart arc', function () {
                     type: 'gauge'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have correct d for Pi radian gauge', function () {
@@ -142,7 +142,7 @@ describe('c3 chart arc', function () {
                     startingAngle: Math.PI/2
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have correct d for 2 Pi radian gauge starting at Pi/2', function() {

--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -35,7 +35,7 @@ describe('c3 chart axis', function () {
 
         it('should update args to have only 1 tick on y axis', function () {
             args.axis.y.tick.count = 1;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have only 1 tick on y axis', function () {
@@ -45,7 +45,7 @@ describe('c3 chart axis', function () {
 
         it('should update args to have 2 ticks on y axis', function () {
             args.axis.y.tick.count = 2;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have 2 ticks on y axis', function () {
@@ -55,7 +55,7 @@ describe('c3 chart axis', function () {
 
         it('should update args to have 3 ticks on y axis', function () {
             args.axis.y.tick.count = 3;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have 3 ticks on y axis', function () {
@@ -71,7 +71,7 @@ describe('c3 chart axis', function () {
 
         it('should update args to have only 2 ticks on y axis', function () {
             args.axis.y.tick.values = values;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have only 2 tick on y axis', function () {
@@ -107,7 +107,7 @@ describe('c3 chart axis', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have 7 ticks on y axis', function () {
@@ -131,7 +131,7 @@ describe('c3 chart axis', function () {
                 value : 'seconds',
                 interval : 60
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have 4 ticks on y axis', function () {
@@ -202,7 +202,7 @@ describe('c3 chart axis', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should construct indexed x axis properly', function () {
@@ -230,7 +230,7 @@ describe('c3 chart axis', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should split x axis tick text to multiple lines', function () {
@@ -293,7 +293,7 @@ describe('c3 chart axis', function () {
                         ['data1', 3000000000000000, 200, 100, 400, 150, 250],
                         ['data2', 50, 20, 10, 40, 15, 25]
                     ];
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should not split y axis tick text to multiple lines', function () {
@@ -310,7 +310,7 @@ describe('c3 chart axis', function () {
 
                 it('should update args to rotate axis', function () {
                     args.axis.rotated = true;
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should split x axis tick text to multiple lines', function () {
@@ -383,7 +383,7 @@ describe('c3 chart axis', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should locate ticks properly', function () {
@@ -431,7 +431,7 @@ describe('c3 chart axis', function () {
 
                 it('should update args to rotate axis', function () {
                     args.axis.rotated = true;
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should locate ticks on rotated axis properly', function () {
@@ -484,7 +484,7 @@ describe('c3 chart axis', function () {
                         args.axis.x.tick = {
                             multiline: false
                         };
-                        expect(true).toBeTruthy();
+                        expect(false).toBeTruthy();
                     });
 
                     it('should split x tick', function () {
@@ -501,7 +501,7 @@ describe('c3 chart axis', function () {
                         args.axis.x.tick = {
                             width: 150
                         };
-                        expect(true).toBeTruthy();
+                        expect(false).toBeTruthy();
                     });
 
                     it('should split x tick to 2 lines properly', function () {
@@ -535,7 +535,7 @@ describe('c3 chart axis', function () {
                 args.axis.x.tick.format = function () {
                     return ['this is a very long tick text', 'on category axis'];
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have multiline tick text', function () {
@@ -575,7 +575,7 @@ describe('c3 chart axis', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should rotate tick texts', function () {
@@ -620,7 +620,7 @@ describe('c3 chart axis', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should rotate tick texts', function () {
@@ -656,7 +656,7 @@ describe('c3 chart axis', function () {
                         ]
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show fitted ticks on indexed data', function () {
@@ -676,7 +676,7 @@ describe('c3 chart axis', function () {
                         ]
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show fitted ticks on indexed data', function () {
@@ -712,7 +712,7 @@ describe('c3 chart axis', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show fitted ticks on indexed data', function () {
@@ -730,7 +730,7 @@ describe('c3 chart axis', function () {
                         ['data3', 150, 120, 110, 140, 115, 125]
                     ]
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show fitted ticks on indexed data', function () {
@@ -764,7 +764,7 @@ describe('c3 chart axis', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not have inner y axis', function () {
@@ -778,7 +778,7 @@ describe('c3 chart axis', function () {
 
         it('should update args to have inner y axis', function () {
             args.axis.y.inner = true;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have inner y axis', function () {
@@ -809,7 +809,7 @@ describe('c3 chart axis', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not have inner y axis', function () {
@@ -823,7 +823,7 @@ describe('c3 chart axis', function () {
 
         it('should update args to have inner y axis', function () {
             args.axis.y2.inner = true;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have inner y axis', function () {

--- a/spec/core-spec.js
+++ b/spec/core-spec.js
@@ -29,7 +29,7 @@ describe('c3 chart', function () {
 
         it('should set 3rd party property to Function', function () {
             Function.prototype.$extIsFunction = true;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be created even if 3rd party property has been set', function () {
@@ -64,7 +64,7 @@ describe('c3 chart', function () {
             it('update args', function () {
                 d3.select('#chart').html('');
                 args.bindto = '#chart';
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should be created', function () {
                 var svg = d3.select('#chart svg');
@@ -76,7 +76,7 @@ describe('c3 chart', function () {
             it('update args', function () {
                 d3.select('#chart').html('');
                 args.bindto = d3.select('#chart');
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should be created', function () {
                 var svg = d3.select('#chart svg');
@@ -88,7 +88,7 @@ describe('c3 chart', function () {
             it('update args', function () {
                 d3.select('#chart').html('');
                 args.bindto = null;
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should not be created', function () {
                 var svg = d3.select('#chart svg');
@@ -100,7 +100,7 @@ describe('c3 chart', function () {
             it('update args', function () {
                 d3.select('#chart').html('');
                 args.bindto = '';
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should not be created', function () {
                 var svg = d3.select('#chart svg');
@@ -121,7 +121,7 @@ describe('c3 chart', function () {
                     ]
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should generate a chart', function () {
@@ -145,7 +145,7 @@ describe('c3 chart', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should generate a chart', function () {

--- a/spec/data-spec.js
+++ b/spec/data-spec.js
@@ -18,7 +18,7 @@ describe('c3 chart data', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should draw correctly', function () {
@@ -57,7 +57,7 @@ describe('c3 chart data', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should draw correctly', function () {
@@ -112,7 +112,7 @@ describe('c3 chart data', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should draw nested JSON correctly', function () {
@@ -179,7 +179,7 @@ describe('c3 chart data', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should return false in isOrderAsc and isOrderDesc functions', function () {
@@ -199,7 +199,7 @@ describe('c3 chart data', function () {
                     ],
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         describe('normal x', function () {
@@ -240,7 +240,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have correct number of xs', function () {
@@ -279,7 +279,7 @@ describe('c3 chart data', function () {
                                 }
                             }
                         };
-                        expect(true).toBeTruthy();
+                        expect(false).toBeTruthy();
                     });
 
                     it('should have correct number of xs', function () {
@@ -326,7 +326,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have correct number of xs', function () {
@@ -373,7 +373,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have correct number of xs', function () {
@@ -412,7 +412,7 @@ describe('c3 chart data', function () {
                         labels: true,
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should locate data labels in correct position', function () {
@@ -439,7 +439,7 @@ describe('c3 chart data', function () {
 
             it('should update args to be stacked', function () {
                 args.data.groups = [['data1', 'data2'], ['data3', 'data4']];
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should locate data labels in correct position', function () {
@@ -481,7 +481,7 @@ describe('c3 chart data', function () {
                         labels: true,
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should locate data labels in correct position', function () {
@@ -508,7 +508,7 @@ describe('c3 chart data', function () {
 
             it('should update args to be stacked', function () {
                 args.data.groups = [['data1', 'data2'], ['data3', 'data4']];
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should locate data labels in correct position', function () {
@@ -550,7 +550,7 @@ describe('c3 chart data', function () {
                         labels: true,
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should locate data labels in correct position', function () {
@@ -577,7 +577,7 @@ describe('c3 chart data', function () {
 
             it('should update args to be stacked', function () {
                 args.data.groups = [['data1', 'data2'], ['data3', 'data4']];
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should locate data labels in correct position', function () {
@@ -617,7 +617,7 @@ describe('c3 chart data', function () {
                         labels: true
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have data labels on all data', function () {
@@ -653,7 +653,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have data labels on all data', function () {
@@ -686,7 +686,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have data labels on all data', function () {
@@ -715,7 +715,7 @@ describe('c3 chart data', function () {
                         labels: true
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have proper y domain', function () {
@@ -746,7 +746,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -768,7 +768,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -797,7 +797,7 @@ describe('c3 chart data', function () {
                     args.axis = {
                         rotated: true
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -819,7 +819,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -864,7 +864,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -886,7 +886,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -915,7 +915,7 @@ describe('c3 chart data', function () {
                     args.axis = {
                         rotated: true
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -937,7 +937,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -982,7 +982,7 @@ describe('c3 chart data', function () {
                             }
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1004,7 +1004,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1032,7 +1032,7 @@ describe('c3 chart data', function () {
                     args.axis = {
                         rotated: true
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1054,7 +1054,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1094,7 +1094,7 @@ describe('c3 chart data', function () {
                             type: 'bar',
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1116,7 +1116,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1145,7 +1145,7 @@ describe('c3 chart data', function () {
                     args.axis = {
                         rotated: true
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1167,7 +1167,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1207,7 +1207,7 @@ describe('c3 chart data', function () {
                             type: 'bar',
                         }
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1229,7 +1229,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1258,7 +1258,7 @@ describe('c3 chart data', function () {
                     args.axis = {
                         rotated: true
                     };
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {
@@ -1280,7 +1280,7 @@ describe('c3 chart data', function () {
 
                 it('should update args', function () {
                     args.data.type = 'line';
-                    expect(true).toBeTruthy();
+                    expect(false).toBeTruthy();
                 });
 
                 it('should have y domain with proper padding', function () {

--- a/spec/domain-spec.js
+++ b/spec/domain-spec.js
@@ -24,7 +24,7 @@ describe('c3 chart domain', function () {
 
         it('should change axis.y.min to -100', function () {
             args.axis.y.min = -100;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be set properly when smaller than max of data', function () {
@@ -35,7 +35,7 @@ describe('c3 chart domain', function () {
 
         it('should change axis.y.min to 500', function () {
             args.axis.y.min = 500;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be set properly when bigger than max of data', function () {
@@ -46,7 +46,7 @@ describe('c3 chart domain', function () {
 
         it('should change axis.y.min to undefined', function () {
             args.axis.y.min = undefined;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
     });
@@ -55,7 +55,7 @@ describe('c3 chart domain', function () {
 
         it('should change axis.y.max to 1000', function () {
             args.axis.y.max = 1000;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be set properly when bigger than min of data', function () {
@@ -66,7 +66,7 @@ describe('c3 chart domain', function () {
 
         it('should change axis.y.max to 0', function () {
             args.axis.y.max = 0;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be set properly when smaller than min of data', function () {
@@ -93,7 +93,7 @@ describe('c3 chart domain', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be set properly when bigger than min of data', function () {
@@ -119,7 +119,7 @@ describe('c3 chart domain', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be set properly when bigger than min of data', function () {

--- a/spec/grid-spec.js
+++ b/spec/grid-spec.js
@@ -28,7 +28,7 @@ describe('c3 chart grid', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not show y grids', function () {
@@ -37,7 +37,7 @@ describe('c3 chart grid', function () {
 
         it('should update args to show y grids', function () {
             args.grid.y.show = true;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should show y grids', function () {
@@ -48,7 +48,7 @@ describe('c3 chart grid', function () {
 
         it('should update args to show only 3 y grids', function () {
             args.grid.y.ticks = 3;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should show only 3 y grids', function () {
@@ -59,7 +59,7 @@ describe('c3 chart grid', function () {
 
         it('should update args to show y grids depending on y axis ticks', function () {
             args.axis.y.tick.count = 5;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should show grids depending on y axis ticks', function () {
@@ -98,7 +98,7 @@ describe('c3 chart grid', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show 3 grid lines', function () {
@@ -147,7 +147,7 @@ describe('c3 chart grid', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show 3 grid lines', function () {
@@ -200,7 +200,7 @@ describe('c3 chart grid', function () {
                         }
                     },
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show 3 grid lines', function () {
@@ -249,7 +249,7 @@ describe('c3 chart grid', function () {
                         }
                     },
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show 3 grid lines', function () {
@@ -300,7 +300,7 @@ describe('c3 chart grid', function () {
                         top: 50
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show x grid lines', function () {
@@ -343,7 +343,7 @@ describe('c3 chart grid', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show x grid lines', function () {

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -22,7 +22,7 @@ describe('c3 chart interaction', function () {
                         type: 'bar'
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have 4 event rects properly', function () {
@@ -46,7 +46,7 @@ describe('c3 chart interaction', function () {
                         type: 'bar'
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have 1 event rects properly', function () {
@@ -72,7 +72,7 @@ describe('c3 chart interaction', function () {
                         ]
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have 4 event rects properly', function () {
@@ -96,7 +96,7 @@ describe('c3 chart interaction', function () {
                         ]
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should have 1 event rects properly', function () {

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -19,7 +19,7 @@ describe('c3 chart legend', function () {
                     ]
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should update args with long data names', function () {
@@ -32,7 +32,7 @@ describe('c3 chart legend', function () {
                     ]
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have properly computed legend width', function () {
@@ -57,7 +57,7 @@ describe('c3 chart legend', function () {
                     ]
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be located on the center of chart', function () {
@@ -84,7 +84,7 @@ describe('c3 chart legend', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should be positioned properly', function () {
@@ -100,7 +100,7 @@ describe('c3 chart legend', function () {
 
         it('should change the legend step to 1 successfully', function () {
             args.legend.inset.step = 1;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have automatically calculated height', function () {
@@ -110,7 +110,7 @@ describe('c3 chart legend', function () {
 
         it('should change the legend step to 2 successfully', function () {
             args.legend.inset.step = 2;
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should have automatically calculated height', function () {
@@ -129,7 +129,7 @@ describe('c3 chart legend', function () {
                     position: 'inset'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should locate legend properly', function () {
@@ -154,7 +154,7 @@ describe('c3 chart legend', function () {
                     hide: true
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not show legends', function () {
@@ -175,7 +175,7 @@ describe('c3 chart legend', function () {
                     hide: 'data2'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not show legends', function () {
@@ -199,7 +199,7 @@ describe('c3 chart legend', function () {
                     show: false
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not initially have rendered any legend items', function () {
@@ -235,7 +235,7 @@ describe('c3 chart legend', function () {
                     }
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('renders the legend item with the correct width and height', function () {
@@ -260,7 +260,7 @@ describe('c3 chart legend', function () {
                     padding: 10
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('renders the correct amount of padding on the legend element', function () {

--- a/spec/shape.bar-spec.js
+++ b/spec/shape.bar-spec.js
@@ -25,7 +25,7 @@ describe('c3 chart shape bar', function () {
                         type: 'bar'
                     },
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should be stacked', function () {
                 var expectedBottom = [275, 293, 365, 281, 395, 290];
@@ -57,7 +57,7 @@ describe('c3 chart shape bar', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should be stacked', function () {
                 var expectedBottom = [275, 293, 365, 281, 395, 290];
@@ -89,7 +89,7 @@ describe('c3 chart shape bar', function () {
                         }
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
             it('should be stacked', function () {
                 var expectedBottom = [275, 293, 365, 281, 395, 290];
@@ -120,7 +120,7 @@ describe('c3 chart shape bar', function () {
                         rotated: false
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should not be within bar', function () {
@@ -153,7 +153,7 @@ describe('c3 chart shape bar', function () {
 
             it('should change the chart as axis rotated', function () {
                 args.axis.rotated = true;
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should not be within bar', function () {

--- a/spec/shape.line-spec.js
+++ b/spec/shape.line-spec.js
@@ -22,7 +22,7 @@ describe('c3 chart shape line', function () {
                     type: 'line'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
 
         });
 
@@ -44,7 +44,7 @@ describe('c3 chart shape line', function () {
 
         it('should change to step chart', function () {
             args.data.type = 'step';
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it("should have shape-rendering = crispedges when it's step chart", function () {
@@ -56,7 +56,7 @@ describe('c3 chart shape line', function () {
 
         it('should change to spline chart', function () {
             args.data.type = 'spline';
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should use cardinal interpolation by default', function () {
@@ -78,7 +78,7 @@ describe('c3 chart shape line', function () {
                     type: 'line'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should not show the circle for null', function (done) {
@@ -115,7 +115,7 @@ describe('c3 chart shape line', function () {
         //             type: 'scatter'
         //         }
         //     };
-        //     expect(true).toBeTruthy();
+        //     expect(false).toBeTruthy();
         // });
 
         // it('should not show the circle for null', function (done) {
@@ -149,7 +149,7 @@ describe('c3 chart shape line', function () {
                 }
             };
 
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should update interpolation function', function() {
@@ -158,7 +158,7 @@ describe('c3 chart shape line', function () {
 
         it('should not use a non-valid interpolation', function () {
             args.spline.interpolation.type = 'foo';
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should use cardinal interpolation when given option is not valid', function() {

--- a/spec/tooltip-spec.js
+++ b/spec/tooltip-spec.js
@@ -47,7 +47,7 @@ describe('c3 chart tooltip', function () {
 
             it('should set left margin', function () {
                 d3.select('#chart').style('margin-left', '300px');
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should show tooltip on proper position', function () {

--- a/spec/type-spec.js
+++ b/spec/type-spec.js
@@ -22,7 +22,7 @@ describe('c3 chart types', function () {
                         type: 'pie'
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should return true', function () {
@@ -31,7 +31,7 @@ describe('c3 chart types', function () {
 
             it('should change chart type to "bar"', function () {
                 args.data.type = 'bar';
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should return false', function () {
@@ -49,7 +49,7 @@ describe('c3 chart types', function () {
                         type: 'pie'
                     }
                 };
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should return true', function () {
@@ -58,7 +58,7 @@ describe('c3 chart types', function () {
 
             it('should change chart type to "bar"', function () {
                 args.data.type = 'bar';
-                expect(true).toBeTruthy();
+                expect(false).toBeTruthy();
             });
 
             it('should return false', function () {
@@ -82,7 +82,7 @@ describe('c3 chart types', function () {
                     type: 'pie'
                 }
             };
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should return true for "pie" type', function () {
@@ -99,7 +99,7 @@ describe('c3 chart types', function () {
 
         it('should unload successfully', function () {
             chart.unload([]);
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should return true for "pie" type even if no data', function () {
@@ -116,7 +116,7 @@ describe('c3 chart types', function () {
 
         it('should change chart type to "bar" successfully', function () {
             args.data.type = 'bar';
-            expect(true).toBeTruthy();
+            expect(false).toBeTruthy();
         });
 
         it('should return false for "pie" type even if no data', function () {


### PR DESCRIPTION
See #1843. Because these cases have more than just the assertion, they won't fail if these assertions are simply removed. As such, I've explicitly set them to fail so we have a better idea of what our test coverage is. It's going to be _well fun_ getting back to a state where tests pass... :weary:

This shouldn't probably be merged for the moment until we agree this is the best course of action at the moment.
