### PR TITLE
Prevent beginning of title from being clipped when title is centereed

### DIFF
--- a/src/title.js
+++ b/src/title.js
@@ -15,7 +15,7 @@ c3_chart_internal_fn.xForTitle = function () {
     if (position.indexOf('right') >= 0) {
         x = $$.currentWidth - $$.getTextRect($$.title.node().textContent, $$.CLASS.title, $$.title.node()).width - config.title_padding.right;
     } else if (position.indexOf('center') >= 0) {
-        x = ($$.currentWidth - $$.getTextRect($$.title.node().textContent, $$.CLASS.title, $$.title.node()).width) / 2;
+        x = Math.max(($$.currentWidth - $$.getTextRect($$.title.node().textContent, $$.CLASS.title, $$.title.node()).width) / 2, 0);
     } else { // left
         x = config.title_padding.left;
     }


### PR DESCRIPTION
When a title is centered and is too long to fit across, the current behavior is to keep it centered and clip both the beginning and the end of the title, making it illegible.

This change never allows the title to be clipped at the beginning, only the end, making chart titles readable even if too long.
