### PR TITLE
Redraw the area before calling transition if doing a flow redraw

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -645,6 +645,8 @@ c3_chart_internal_fn.redraw = function (options, transitions) {
             xForText: xForText,
             yForText: yForText
         });
+
+        $$.redrawArea(drawArea);
     }
 
     if ((duration || flow) && $$.isTabVisible()) { // Only use transition if tab visible. See #938.


### PR DESCRIPTION
Fairly minimal change to fix the problem I've seen in #1880. This draws the area of the graph outside the drawing area before it is slided in avoiding the transition flicker.