### PR TITLE
Fix for issue #1873

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1036,6 +1036,8 @@ c3_chart_internal_fn.parseDate = function (date) {
         parsedDate = date;
     } else if (typeof date === 'string') {
         parsedDate = $$.dataTimeFormat($$.config.data_xFormat).parse(date);
+    } else if (typeof date === 'object') {
+        parsedDate = new Date(+date);
     } else if (typeof date === 'number' && !isNaN(date)) {
         parsedDate = new Date(+date);
     }


### PR DESCRIPTION
Attempt parsing object (ex Moment.js date object) to date. This was implicitly supported <= v0.4.10 but regressed with narrower validation in #1121.

---
close #1873