### PR TITLE
padAngle options implementation for pie/donut

### DIFF
--- a/spec/arc-spec.js
+++ b/spec/arc-spec.js
@@ -95,6 +95,28 @@ describe('c3 chart arc', function () {
             expect(arcs.data3.attr('d').indexOf('NaN')).toBe(-1);
         });
 
+        it('should set args with data padAngle that can be padded', function () {
+            var padAngle = 0.05;
+
+            args = {
+                data: {
+                    columns: [
+                        ['data1', 60],
+                        ['data2', 40]
+                    ],
+                    type: 'donut'
+                },
+                donut: {
+                    padAngle: padAngle
+                }
+            };
+            expect(true).toBeTruthy();
+        });
+
+        it('should set padAngle value', function () {
+            var padAngle = chart.internal.pie.padAngle();
+            expect(true).toBe(padAngle > 0);
+        });
     });
 
     describe('show gauge', function () {

--- a/src/arc.js
+++ b/src/arc.js
@@ -1,6 +1,6 @@
 c3_chart_internal_fn.initPie = function () {
     var $$ = this, d3 = $$.d3, config = $$.config;
-    $$.pie = d3.layout.pie().value(function (d) {
+    $$.pie = d3.layout.pie().padAngle( config[ config.data_type +"_padAngle" ] || 0 ).value(function (d) {
         return d.values.reduce(function (a, b) { return a + b.value; }, 0);
     });
     if (!config.data_order) {

--- a/src/config.js
+++ b/src/config.js
@@ -121,7 +121,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         axis_y_label: {},
         axis_y_tick_format: undefined,
         axis_y_tick_outer: true,
-        axis_y_tick_values: null,        
+        axis_y_tick_values: null,
         axis_y_tick_rotate: 0,
         axis_y_tick_count: undefined,
         axis_y_tick_time_value: undefined,
@@ -177,6 +177,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         pie_label_ratio: undefined,
         pie_expand: {},
         pie_expand_duration: 50,
+        pie_padAngle: 0,
         // gauge
         gauge_fullCircle: false,
         gauge_label_show: true,
@@ -198,6 +199,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         donut_title: "",
         donut_expand: {},
         donut_expand_duration: 50,
+        donut_padAngle: 0,
         // spline
         spline_interpolation_type: 'cardinal',
         // region - region to change style


### PR DESCRIPTION
New options setting padded values

![image](https://cloud.githubusercontent.com/assets/2178435/21671937/51551cf6-d362-11e6-836a-bd75ba8bbd1f.png)

Options interface:
```js
donut : {
    padAngle: 0.04,
},
pie: {
    padAngle: 0.05
}
```

Ref #1920