### PR TITLE
Style empty points in line charts via CSS

### DIFF
--- a/src/scss/point.scss
+++ b/src/scss/point.scss
@@ -1,3 +1,6 @@
+.c3-circle {
+  fill: currentColor;
+}
 .c3-circle._expanded_ {
   stroke-width: 1px;
   stroke: white;

--- a/src/shape.line.js
+++ b/src/shape.line.js
@@ -307,7 +307,7 @@ c3_chart_internal_fn.updateCircle = function () {
     $$.mainCircle.enter().append("circle")
         .attr("class", $$.classCircle.bind($$))
         .attr("r", $$.pointR.bind($$))
-        .style("fill", $$.color);
+        .style("color", $$.color);
     $$.mainCircle
         .style("opacity", $$.initialOpacityForCircle.bind($$));
     $$.mainCircle.exit().remove();
@@ -317,7 +317,7 @@ c3_chart_internal_fn.redrawCircle = function (cx, cy, withTransition) {
     return [
         (withTransition ? this.mainCircle.transition(Math.random().toString()) : this.mainCircle)
             .style('opacity', this.opacityForCircle.bind(this))
-            .style("fill", this.color)
+            .style("color", this.color)
             .attr("cx", cx)
             .attr("cy", cy),
         (withTransition ? selectedCircles.transition(Math.random().toString()) : selectedCircles)


### PR DESCRIPTION
moved point color from fill to color to let the possibility to use the color for stroke via css like: 

```
  .c3-circle {
    fill: white;
    stroke: currentColor;
    stroke-width: 2px;
  }
```

![screen shot 2017-03-15 at 4 19 14 pm](https://cloud.githubusercontent.com/assets/1897574/23955757/29e15be8-099b-11e7-934c-35f109213f78.png)