### PR TITLE
Fix prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "D3-based reusable chart library",
   "main": "c3.js",
   "scripts": {
-    "prepublish": "grunt",
+    "prepublish": "npm run dist",
     "lint": "grunt lint",
     "build": "rollup -f umd --name c3 src/index.js > c3.js",
     "minify": "grunt minify",


### PR DESCRIPTION
Master's build is failing because of prepublish script's bug.

I set prepublish script `grunt` at #2041 but also I deleted grunt `default` task in #2037 . This PR resolves the conflict between those 2 changes.