### PR TITLE
Improves linting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+    "esversion": 6,
     "eqeqeq": true,
     "curly": true,
     "strict": false,
@@ -8,7 +9,6 @@
     "undef": true,
     "unused": true,
     "indent": 4,
-
     "eqnull": true,
     "expr": true,
     "newcap": false,
@@ -16,18 +16,9 @@
     "bitwise": false,
 
     "browser": true,
+    "jasmine": true,
 
     "globals": {
-        "jasmine": false,
-        "describe": false,
-        "beforeEach": false,
-        "beforeAll": false,
-        "it": false,
-        "expect": false,
-        "d3": false,
-        "module": false,
-        "require": false,
-        "define": false
+        "d3": false
     }
-
 }

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -8,8 +8,8 @@ module.exports = (grunt) ->
             files: ['src/scss/*.scss']
 
         jshint:
-          c3: 'c3.js'
-          spec: 'spec/*.js'
+          c3: 'src/**/*.js'
+          spec: 'spec/**/*.js'
           options:
             reporter: require('jshint-stylish')
             jshintrc: '.jshintrc'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublish": "npm run dist",
     "lint": "grunt lint",
-    "build": "rollup -f umd --name c3 src/index.js > c3.js",
+    "build": "rollup -f umd --name c3 --globals d3:d3 src/index.js > c3.js",
     "minify": "grunt minify",
     "test": "npm run build && npm run lint && karma start karma.conf.js",
     "dist": "npm run build && npm run minify",

--- a/src/api.region.js
+++ b/src/api.region.js
@@ -1,6 +1,5 @@
 import CLASS from './class';
 import { c3_chart_fn } from './core';
-import { getOption } from './util';
 
 c3_chart_fn.regions = function (regions) {
     var $$ = this.internal, config = $$.config;

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,7 +1,7 @@
 import CLASS from './class';
-import { inherit, API } from './core'
+import { inherit, API } from './core';
 import { isValue, isFunction, isString, isEmpty } from './util';
-import c3_axis from './c3.axis'
+import c3_axis from './c3.axis';
 
 export default function Axis(owner) {
     API.call(this, owner);

--- a/src/class-utils.js
+++ b/src/class-utils.js
@@ -1,4 +1,4 @@
-import CLASS from './class'
+import CLASS from './class';
 import { c3_chart_internal_fn } from './core';
 
 c3_chart_internal_fn.generateClass = function (prefix, targetId) {

--- a/src/core.js
+++ b/src/core.js
@@ -1,3 +1,4 @@
+import * as d3 from 'd3';
 import Axis from './axis';
 import CLASS from './class';
 import { isValue, isFunction, isString, isUndefined, isDefined, ceil10, asHalfPixel, diffDomain, isEmpty, notEmpty, getOption, hasValue, sanitise, getPathBox } from './util';
@@ -7,8 +8,6 @@ export var c3 = { version: "0.4.11" };
 export var c3_chart_fn;
 export var c3_chart_internal_fn;
 export var c3_chart_internal_axis_fn;
-
-var d3 = window.d3 ? window.d3 : typeof require !== 'undefined' ? require("d3") : undefined;
 
 export function API(owner) {
     this.owner = owner;
@@ -50,7 +49,7 @@ function Chart(config) {
 
 function ChartInternal(api) {
     var $$ = this;
-    $$.d3 = d3
+    $$.d3 = d3;
     $$.api = api;
     $$.config = $$.getDefaultConfig();
     $$.data = {};
@@ -1084,4 +1083,3 @@ c3_chart_internal_fn.hasValue = hasValue;
 c3_chart_internal_fn.sanitise = sanitise;
 c3_chart_internal_fn.getPathBox = getPathBox;
 c3_chart_internal_fn.CLASS = CLASS;
-

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { c3 } from './core'
+import { c3 } from './core';
 
 import './polyfill';
 
@@ -55,4 +55,4 @@ import './ua';
 import './util';
 import './zoom';
 
-export default c3
+export default c3;

--- a/src/title.js
+++ b/src/title.js
@@ -1,4 +1,3 @@
-import CLASS from './class';
 import { c3_chart_internal_fn } from './core';
 
 c3_chart_internal_fn.initTitle = function () {


### PR DESCRIPTION
Previously, linting was done on the generated file and not on the component modules. This makes jshint now lint the modules instead and fixes any outstanding linting errors.

Note, this also now simply imports D3 in src/core.js:

```diff
+import * as d3 from 'd3';
-var d3 = window.d3 ? window.d3 : typeof require !== 'undefined' ? require("d3") : undefined;
```
I think this is desirable but am open to discussion.