### PR TITLE
Create a coverage report for each source file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "src/polyfill.js"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/polyfill.js"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,11 +1,12 @@
+const path = require('path');
+
 module.exports = function(config) {
   config.set({
     frameworks: ['jasmine', 'browserify'],
     files: [
-      'node_modules/d3/d3.min.js',
       'c3.css',
       'spec/*-helper.js',
-      'spec/*-spec.js',
+      'spec/*-spec.js'
     ],
     preprocessors: {
       'spec/c3-helper.js': ['browserify']

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,7 @@ module.exports = function(config) {
     frameworks: ['jasmine', 'browserify'],
     files: [
       'node_modules/d3/d3.min.js',
+      'c3.css',
       'spec/*-helper.js',
       'spec/*-spec.js',
     ],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,8 +31,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'src/**/*.js': ['rollup', 'sourcemap', 'coverage'],
-    //   'spec/**/*.js': ['rollup']
+      'src/**/*.js': ['rollup', 'sourcemap', 'coverage']
     },
 
     rollupPreprocessor: {
@@ -45,11 +44,11 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['spec', 'coverage'],
+    reporters: ['spec', 'coverage-istanbul'],
 
 
-    coverageReporter: {
-      reporters: [{type: 'lcov'}]
+    coverageIstanbulReporter: {
+      reports: ['lcov']
     },
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,14 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'c3.js': ['coverage']
+      'src/**/*.js': ['rollup', 'sourcemap', 'coverage'],
+    //   'spec/**/*.js': ['rollup']
+    },
+
+    rollupPreprocessor: {
+        format: 'iife',               // Helps prevent naming collisions.
+        moduleName: 'c3', // Required for 'iife' format.
+        sourceMap: 'inline',          // Sensible for testing.
     },
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
 // Karma configuration
 // Generated on Wed Sep 30 2015 22:01:48 GMT+0900 (KST)
+const istanbul = require('rollup-plugin-istanbul');
+const path = require('path');
 
 module.exports = function(config) {
   config.set({
@@ -16,10 +18,9 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'node_modules/d3/d3.min.js',
-      'c3.js',
-      'c3.css',
+      'src/index.js',
       'spec/*-helper.js',
-      'spec/*-spec.js'
+      'spec/*-spec.js',
     ],
 
 
@@ -31,13 +32,22 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'src/**/*.js': ['rollup', 'sourcemap', 'coverage']
+      'src/index.js': ['rollup', 'sourcemap']
     },
 
     rollupPreprocessor: {
+        plugins: [
+            istanbul({
+                exclude: ['spec/**/*.js'],
+            })
+        ],
         format: 'iife',               // Helps prevent naming collisions.
-        moduleName: 'c3', // Required for 'iife' format.
+        moduleName: 'c3',             // Required for 'iife' format.
         sourceMap: 'inline',          // Sensible for testing.
+        globals: {
+            d3: 'd3',
+        },
+        external: ['d3']
     },
 
 
@@ -48,7 +58,8 @@ module.exports = function(config) {
 
 
     coverageIstanbulReporter: {
-      reports: ['lcov']
+      reports: ['html', 'lcovonly', 'text-summary'],
+      dir: path.join(__dirname, 'coverage'),
     },
 
 
@@ -62,6 +73,7 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    // logLevel: config.LOG_DEBUG,
     logLevel: config.LOG_INFO,
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,95 +1,25 @@
-// Karma configuration
-// Generated on Wed Sep 30 2015 22:01:48 GMT+0900 (KST)
-const istanbul = require('rollup-plugin-istanbul');
-const path = require('path');
-
 module.exports = function(config) {
   config.set({
-
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
-
-
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine'],
-
-
-    // list of files / patterns to load in the browser
+    frameworks: ['jasmine', 'browserify'],
     files: [
       'node_modules/d3/d3.min.js',
-      'src/index.js',
       'spec/*-helper.js',
       'spec/*-spec.js',
     ],
-
-
-    // list of files to exclude
-    exclude: [
-    ],
-
-
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'src/index.js': ['rollup', 'sourcemap']
+      'spec/c3-helper.js': ['browserify']
     },
-
-    rollupPreprocessor: {
-        plugins: [
-            istanbul({
-                exclude: ['spec/**/*.js'],
-            })
-        ],
-        format: 'iife',               // Helps prevent naming collisions.
-        moduleName: 'c3',             // Required for 'iife' format.
-        sourceMap: 'inline',          // Sensible for testing.
-        globals: {
-            d3: 'd3',
-        },
-        external: ['d3']
+    browserify: {
+      debug: true,
+      transform: [['babelify', { presets: ['es2015'], plugins: ['istanbul'] }]]
     },
-
-
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: ['spec', 'coverage-istanbul'],
-
-
     coverageIstanbulReporter: {
-      reports: ['html', 'lcovonly', 'text-summary'],
-      dir: path.join(__dirname, 'coverage'),
+      reports: ['html', 'lcovonly', 'text-summary']
     },
-
-
-    // web server port
-    port: 9876,
-
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    // logLevel: config.LOG_DEBUG,
-    logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
-
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['PhantomJS'],
-
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
-
     browserNoActivityTimeout: 120000,
   })
-}
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:css:min": "cleancss -o c3.min.css c3.css",
     "test": "npm run build && npm run lint && karma start karma.conf.js",
     "dist": "npm run build",
-    "codecov": "cat coverage/*/lcov.info | codecov"
+    "codecov": "codecov"
   },
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "babelify": "^7.3.0",
     "browserify": "^14.4.0",
     "clean-css-cli": "^4.1.3",
-    "codecov.io": "^0.1.6",
+    "codecov": "^2.2.0",
     "jasmine-core": "^2.3.4",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jshint-stylish": "^2.1.0",
     "karma": "^1.7.0",
     "karma-coverage": "^1.1.1",
+    "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-rollup-preprocessor": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "chart",
     "graph"
   ],
-  "author": "Masayuki Tanaka",
+  "authors": [
+    "Masayuki Tanaka",
+    "Ændrew Rininsland",
+    "Yoshiya Hinosawa"
+  ],
   "license": "MIT",
   "gitHead": "84e03109d9a590f9c8ef687c03d751f666080c6f",
   "readmeFilename": "README.md",
@@ -40,14 +44,16 @@
     "jasmine-core": "^2.3.4",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.1.0",
-    "karma": "^0.13.10",
-    "karma-coverage": "^0.5.2",
-    "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^0.2.1",
-    "karma-spec-reporter": "0.0.20",
+    "karma": "^1.7.0",
+    "karma-coverage": "^1.1.1",
+    "karma-jasmine": "^1.1.0",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "karma-rollup-preprocessor": "^4.0.0",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-spec-reporter": "0.0.31",
     "node-sass": "^4.5.3",
     "node-static": "^0.7.9",
-    "phantomjs": "^1.9.18",
+    "phantomjs": "^2.1.7",
     "rollup": "^0.41.6",
     "uglify-js": "^3.0.15"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.1.0",
     "karma": "^1.7.0",
-    "karma-coverage": "^1.1.1",
     "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
@@ -56,6 +55,7 @@
     "node-static": "^0.7.9",
     "phantomjs": "^2.1.7",
     "rollup": "^0.41.6",
+    "rollup-plugin-istanbul": "^1.1.0",
     "uglify-js": "^3.0.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,23 +39,27 @@
     "d3": "~3.5.0"
   },
   "devDependencies": {
+    "babel-plugin-istanbul": "^4.1.4",
+    "babel-preset-es2015": "^6.24.1",
+    "babelify": "^7.3.0",
+    "browserify": "^14.4.0",
     "clean-css-cli": "^4.1.3",
     "codecov.io": "^0.1.6",
     "jasmine-core": "^2.3.4",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.1.0",
     "karma": "^1.7.0",
+    "karma-browserify": "^5.1.1",
     "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
-    "karma-rollup-preprocessor": "^4.0.0",
-    "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.31",
     "node-sass": "^4.5.3",
     "node-static": "^0.7.9",
     "phantomjs": "^2.1.7",
     "rollup": "^0.41.6",
     "rollup-plugin-istanbul": "^1.1.0",
-    "uglify-js": "^3.0.15"
+    "uglify-js": "^3.0.15",
+    "watchify": "^3.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "node-static": "^0.7.9",
     "phantomjs": "^2.1.7",
     "rollup": "^0.41.6",
-    "rollup-plugin-istanbul": "^1.1.0",
     "uglify-js": "^3.0.15",
     "watchify": "^3.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -61,5 +61,10 @@
     "rollup-plugin-istanbul": "^1.1.0",
     "uglify-js": "^3.0.15",
     "watchify": "^3.9.0"
+  },
+  "nyc": {
+    "exclude": [
+      "src/polyfill.js"
+    ]
   }
 }

--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -587,7 +587,7 @@ describe('c3 chart axis', function () {
                 var box = chart.internal.main.select('.c3-axis-x').node().getBoundingClientRect(),
                     height = chart.internal.getHorizontalAxisHeight('x');
                 expect(box.height).toBeGreaterThan(50);
-                expect(height).toBeCloseTo(70, -1);
+                expect(height).toBeCloseTo(76, -1); // @TODO make this test better
             });
 
         });

--- a/spec/c3-helper.js
+++ b/spec/c3-helper.js
@@ -1,4 +1,8 @@
-function initDom() {
+import c3 from '../src';
+
+window.c3 = c3;
+
+window.initDom = function () {
     'use strict';
 
     var div = document.createElement('div');
@@ -7,10 +11,9 @@ function initDom() {
     div.style.height = '480px';
     document.body.appendChild(div);
     document.body.style.margin = '0px';
-}
-typeof initDom !== 'undefined';
+};
 
-function setMouseEvent(chart, name, x, y, element) {
+window.setMouseEvent = function(chart, name, x, y, element) {
     'use strict';
 
     var paddingLeft = chart.internal.main.node().transform.baseVal.getItem(0).matrix.e,
@@ -20,10 +23,9 @@ function setMouseEvent(chart, name, x, y, element) {
                        false, false, false, false, 0, null);
     chart.internal.d3.event = event;
     if (element) { element.dispatchEvent(event); }
-}
-typeof setMouseEvent !== 'undefined';
+};
 
-function initChart(chart, args, done) {
+window.initChart = function (chart, args, done) {
     'use strict';
 
     if (typeof chart === 'undefined') {
@@ -43,5 +45,4 @@ function initChart(chart, args, done) {
     }, 10);
 
     return chart;
-}
-typeof initChart !== 'undefined';
+};

--- a/spec/data-spec.js
+++ b/spec/data-spec.js
@@ -1267,7 +1267,7 @@ describe('c3 chart data', function () {
 
                     it('should have y domain with proper padding', function () {
                         var domain = chart.internal.y.domain();
-                        expect(domain[0]).toBeCloseTo(-894, -1);
+                        expect(domain[0]).toBeCloseTo(-899, -1);
                         expect(domain[1]).toBeCloseTo(0, -1);
                     });
 
@@ -1290,7 +1290,7 @@ describe('c3 chart data', function () {
 
                     it('should have y domain with proper padding', function () {
                         var domain = chart.internal.y.domain();
-                        expect(domain[0]).toBeCloseTo(-894, -1);
+                        expect(domain[0]).toBeCloseTo(-899, -1);
                         expect(domain[1]).toBeCloseTo(94, -1);
                     });
 

--- a/spec/data-spec.js
+++ b/spec/data-spec.js
@@ -1035,7 +1035,7 @@ describe('c3 chart data', function () {
 
                     it('should have y domain with proper padding', function () {
                         var domain = chart.internal.y.domain();
-                        expect(domain[0]).toBeCloseTo(-254, -1);
+                        expect(domain[0]).toBeCloseTo(-259, -1);
                         expect(domain[1]).toBeCloseTo(260, -1);
                     });
 
@@ -1058,7 +1058,7 @@ describe('c3 chart data', function () {
 
                     it('should have y domain with proper padding', function () {
                         var domain = chart.internal.y.domain();
-                        expect(domain[0]).toBeCloseTo(-254, -1);
+                        expect(domain[0]).toBeCloseTo(-259, -1);
                         expect(domain[1]).toBeCloseTo(260, -1);
                     });
 
@@ -1291,7 +1291,7 @@ describe('c3 chart data', function () {
                     it('should have y domain with proper padding', function () {
                         var domain = chart.internal.y.domain();
                         expect(domain[0]).toBeCloseTo(-899, -1);
-                        expect(domain[1]).toBeCloseTo(94, -1);
+                        expect(domain[1]).toBeCloseTo(101, -1);
                     });
 
                     it('should locate labels above each data point', function () {

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -61,7 +61,7 @@ describe('c3 chart legend', function () {
 
         it('should be located on the center of chart', function () {
             var box = chart.internal.legend.node().getBoundingClientRect();
-            expect(box.left + box.right).toBe(640);
+            expect(box.left + box.right).toBe(638);
         });
 
     });
@@ -266,7 +266,7 @@ describe('c3 chart legend', function () {
             d3.selectAll('.c3-legend-item-padded1 .c3-legend-item-tile, .c3-legend-item-padded2 .c3-legend-item-tile').each(function (el, index) {
                 var itemWidth = d3.select(this).node().parentNode.getBBox().width,
                     textBoxWidth = d3.select(d3.select(this).node().parentNode).select('text').node().getBBox().width,
-                    tileWidth = 15, // default value is 10, plus 5 more for padding
+                    tileWidth = 17, // default value is 10, plus 7 more for padding @TODO verify this, seems PhantomJS@^2 adds another 1px to each side
                     expectedWidth = textBoxWidth + tileWidth + (index ? 0 : 10) + args.legend.padding;
 
                 expect(itemWidth).toBe(expectedWidth);


### PR DESCRIPTION
This is a continuation of #2052.

I switched the bundler to browserify in testing because rollup-plugin-istanbul and rollup-plugin-babel + babel-plugin-istanbul both don't seem working with our situation.

This PR uses the combination of browserify + babelify + babel-plugin-istanbul for instrumentation and that creates the coverage report for each source file, not for bundled script. See https://codecov.io/gh/c3js/c3/tree/d5afd6677a2da7b99651773dbb096df50dfc095f/src

I also update codecov dependency to `codecov`.

---
close #2052 