### PR TITLE
Prepare greenkeeper settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,10 @@
       "src/polyfill.js",
       "spec/"
     ]
+  },
+  "greenkeeper": {
+    "ignore": [
+      "d3"
+    ]
   }
 }


### PR DESCRIPTION
- we can not update d3.js right now, so I added a field of greenkeeper to ignore d3 dependency

After this merged, I'll enable greenkeeper on this repository.

---

I followed the instruction below:

<img width="739" alt="2017-07-18 12 39 44" src="https://user-images.githubusercontent.com/613956/28299873-7f6d2646-6bb6-11e7-8970-7b30ce34ccee.png">

https://github.com/kt3k/t10/pull/5