### PR TITLE
Dynamically color stroke when redrawing bars

### DIFF
--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -46,6 +46,7 @@ c3_chart_internal_fn.redrawBar = function (drawBar, withTransition) {
     return [
         (withTransition ? this.mainBar.transition(Math.random().toString()) : this.mainBar)
             .attr('d', drawBar)
+            .style("stroke", this.color)
             .style("fill", this.color)
             .style("opacity", 1)
     ];


### PR DESCRIPTION
Fixes issue https://github.com/c3js/c3/issues/2136 by making redrawBar() consistent with updateBar().