### PR TITLE
Call resize handlers only if chart is displayed

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -937,11 +937,20 @@ c3_chart_internal_fn.bindResize = function () {
     $$.resizeFunction.add(function () {
         config.onresized.call($$);
     });
+    
+    var resizeIfElementDisplayed = function() {
+        // if element not displayed skip it
+        if (!$$.api.element.offsetParent) {
+            return;
+        }
+
+        $$.resizeFunction();
+    };
 
     if (window.attachEvent) {
-        window.attachEvent('onresize', $$.resizeFunction);
+        window.attachEvent('onresize', resizeIfElementDisplayed);
     } else if (window.addEventListener) {
-        window.addEventListener('resize', $$.resizeFunction, false);
+        window.addEventListener('resize', resizeIfElementDisplayed, false);
     } else {
         // fallback to this, if this is a very old browser
         var wrapper = window.onresize;
@@ -955,7 +964,14 @@ c3_chart_internal_fn.bindResize = function () {
         }
         // add this graph to the wrapper, we will be removed if the user calls destroy
         wrapper.add($$.resizeFunction);
-        window.onresize = wrapper;
+        window.onresize = function() {
+            // if element not displayed skip it
+            if (!$$.api.element.offsetParent) {
+                    return;
+            }
+
+            wrapper();
+		};
     }
 };
 


### PR DESCRIPTION
In the current implementation the resize handlers are called even if the chart is not displayed. This is not ideal when having one chart in focus and some hidden ones, as all event handlers get called and performance degrades. Also, while `Chrome` behaves correctly and does not actually change the width of the hidden ones, `Firefox` tries to resize the hidden elements and sets incorrect full widths, visible after the hidden charts are re-displayed. By checking the `offsetParent` we can tell if the chart is displayed or not and we can skip resize handling if hidden. 

@kt3k 