### PR TITLE
Fix destroy function to prevent null error during Pie chart animation

### DIFF
--- a/src/api.chart.js
+++ b/src/api.chart.js
@@ -14,6 +14,9 @@ c3_chart_fn.flush = function () {
 
 c3_chart_fn.destroy = function () {
     var $$ = this.internal;
+    var defaultConfig = $$.getDefaultConfig();
+    //subsequent checks to config should check this instead of !config
+    defaultConfig.destroyed = true;
 
     window.clearInterval($$.intervalForObserveInserted);
 
@@ -37,7 +40,20 @@ c3_chart_fn.destroy = function () {
 
     // MEMO: this is needed because the reference of some elements will not be released, then memory leak will happen.
     Object.keys($$).forEach(function (key) {
-        $$[key] = null;
+        if(key === "config")
+        {
+            $$[key] = defaultConfig;
+        }
+        else if(key === "data")
+        {
+            $$[key] = {
+                targets: []
+            };
+        }
+        else
+        {
+            $$[key] = null;
+        }
     });
 
     return null;

--- a/src/arc.js
+++ b/src/arc.js
@@ -31,7 +31,7 @@ c3_chart_internal_fn.updateAngle = function (d) {
         found = false, index = 0,
         gMin, gMax, gTic, gValue;
 
-    if (!config) {
+    if (config.destroyed) { // chart is destroyed
         return null;
     }
 

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -133,7 +133,7 @@ c3_chart_internal_fn.generateEventRectsForSingleX = function (eventRectEnter) {
         })
         .on('mouseout', function (d) {
             var index = d.index;
-            if (!$$.config) { return; } // chart is destroyed
+            if ($$.config.destroyed) { return; } // chart is destroyed
             if ($$.hasArcType()) { return; }
             $$.hideXGridFocus();
             $$.hideTooltip();
@@ -245,7 +245,7 @@ c3_chart_internal_fn.generateEventRectsForMultipleXs = function (eventRectEnter)
         .attr('height', $$.height)
         .attr('class', CLASS.eventRect)
         .on('mouseout', function () {
-            if (!$$.config) { return; } // chart is destroyed
+            if ($$.config.destroyed) { return; } // chart is destroyed
             if ($$.hasArcType()) { return; }
             mouseout();
         })


### PR DESCRIPTION
addresses https://github.com/c3js/c3/issues/2187
Modified .destroy function to not simply set $$.config and $$.data to null, as during a pie animation, these will quickly be checked as d3 animates things frame by frame. I set config back to the default, and data to an object with an empty targets array.