### PR TITLE
Update rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,11 @@
 import babel from 'rollup-plugin-babel';
 
 export default {
-    entry: 'src/index.js',
-    format: 'umd',
-    moduleName: 'c3',
+    input: 'src/index.js',
+    output: {
+        name: 'c3',
+        format: 'umd'
+    },
     plugins: [babel({
         presets: [['es2015', {
             modules: false


### PR DESCRIPTION
Some properties are deprecated and changed to the other names. (This change removes the warnings on build time.)

---
closes #2271