### PR TITLE
Preserve license in c3.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:js && npm run build:css",
     "build:js": "npm run build:js:rollup && npm run build:js:uglify",
     "build:js:rollup": "rollup -c > c3.js",
-    "build:js:uglify": "uglifyjs c3.js --compress --mangle -o c3.min.js",
+    "build:js:uglify": "uglifyjs c3.js --compress --mangle --comments -o c3.min.js",
     "build:css": "npm run build:css:sass && npm run build:css:min",
     "build:css:sass": "node-sass src/scss/main.scss > c3.css",
     "build:css:min": "cleancss -o c3.min.css c3.css",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,12 @@
 import babel from 'rollup-plugin-babel';
+import pkg from './package.json'
 
 export default {
     input: 'src/index.js',
     output: {
         name: 'c3',
-        format: 'umd'
+        format: 'umd',
+        banner: `/* @license C3.js v${pkg.version} | (c) C3 Team and other contributors | http://c3js.org/ */`
     },
     plugins: [babel({
         presets: [['es2015', {


### PR DESCRIPTION
This change adds the license banner at the top of the bundle

```js
/* @license C3.js v0.4.18 | (c) C3 Team and other contributors | http://c3js.org/ */
!function(t,e){"object"==typeof exports&&"undefined"!=typeof module?mod...
```

---
closes #2277