### PR TITLE
Issues/2251

### DIFF
--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -153,6 +153,25 @@ describe('c3 chart axis', function () {
     });
 
     describe('axis.x.tick.values', function () {
+        describe('formatted correctly when negative', function() {
+            var xValues = [-3.3, -2.2, -1.1, 1.1, 2.2, 3.3];
+            beforeEach(function() {
+                args.data = {
+                    x: 'x',
+                    columns: [
+                        ['x'].concat(xValues),
+                        ['data1', 30, 200, 100, 400, 150, 250],
+                    ]
+                };
+            });
+
+            it ('should not generate whole number for negative values', function() {
+                var tickValues = [];
+                d3.select('.c3-axis-x').selectAll('g.tick').selectAll('tspan').each(function(d, i) { expect(tickValues.push(parseFloat(d.splitted)) === xValues[i]); });
+
+            });
+        });
+
         describe('function is provided', function () {
             var tickGenerator = function () {
                 var values = [];

--- a/src/axis.js
+++ b/src/axis.js
@@ -475,8 +475,15 @@ c3_axis_fn.getId = function getId(id) {
     return id in config.data_axes ? config.data_axes[id] : 'y';
 };
 c3_axis_fn.getXAxisTickFormat = function getXAxisTickFormat() {
-    var $$ = this.owner, config = $$.config,
-        format = $$.isTimeSeries() ? $$.defaultAxisTimeFormat : $$.isCategorized() ? $$.categoryName : function (v) { return v < 0 ? v.toFixed(0) : v; };
+    // #2251 previously set any negative values to a whole number, 
+    // however both should be truncated according to the users format specification
+    var $$ = this.owner, config = $$.config;
+    let format = ($$.isTimeSeries()) 
+        ? $$.defaultAxisTimeFormat 
+        : ($$.isCategorized()) 
+            ? $$.categoryName 
+            : function (v) { return v; };
+            
     if (config.axis_x_tick_format) {
         if (isFunction(config.axis_x_tick_format)) {
             format = config.axis_x_tick_format;


### PR DESCRIPTION
potential fix and tests for #2251.

Tracked getXAxisTickFormat as far back as 1987be65cf7eef5666b191c11cf184e67a3cf5df but couldn't find an explanation for why the change from returning a null value needed to truncate on values < 0, so removed that portion and created matching testcase.