### PR TITLE
Fix bar overlap bug when tick fit is false

### DIFF
--- a/spec/shape.bar-spec.js
+++ b/spec/shape.bar-spec.js
@@ -97,7 +97,6 @@ describe('c3 chart shape bar', function () {
                 });
            });
         });
-
     });
 
     describe('internal.isWithinBar', function () {
@@ -174,6 +173,18 @@ describe('c3 chart shape bar', function () {
 
     });
 
+    var getBBox = function(selector) {
+        return d3.select(selector).node().getBBox();
+    };
+
+    var getBarBBox = function(name, idx) {
+        return getBBox('.c3-target-' + name + ' .c3-bar-' + (idx || 0));
+    };
+
+    var getBarWidth = function(name, idx) {
+      return parseInt(getBarBBox(name, idx).width);
+    };
+
     describe('bar spacing', function() {
 
         var createArgs = function(spacing) {
@@ -199,24 +210,12 @@ describe('c3 chart shape bar', function () {
             };
         };
 
-        var getBBox = function(selector) {
-          return d3.select(selector).node().getBBox();
-        };
-
         var getBarContainerWidth = function() {
             return parseInt(getBBox('.c3-chart-bars').width);
         };
 
         var getBarContainerOffset = function() {
             return parseInt(getBBox('.c3-chart-bars').x);
-        };
-
-        var getBarBBox = function(name, idx) {
-            return getBBox('.c3-target-' + name + ' .c3-bar-' + (idx || 0));
-        };
-
-        var getBarWidth = function(name, idx) {
-          return parseInt(getBarBBox(name, idx).width);
         };
 
         var getBarOffset = function(name1, name2, idx) {
@@ -324,6 +323,63 @@ describe('c3 chart shape bar', function () {
             // the offsets from the first/last chart
             expect(getBarContainerWidth()).toEqual(396 - 15);
             expect(getBarContainerOffset()).toEqual(31 + parseInt(15 / 2));
+        });
+    });
+
+    describe('bar width', function () {
+        var createArgs = function(dataColumns) {
+            return {
+                size: {
+                    width: 500
+                },
+                data: {
+                    x: 'x',
+                    columns: dataColumns,
+                    groups: [
+                        ['data1', 'data2']
+                    ],
+                    type: 'bar',
+                },
+                axis: {
+                    x: {
+                        type: 'timeseries',
+                        tick: {
+                            fit: false,
+                            format: '%Y-%m-%d'
+                        }
+                    }
+                }
+            };
+        };
+
+        it('should set arguments with fewer unique x values than fit false ticks', function () {
+            var data = [
+                ['x', '2016-01-05', '2016-01-06', '2016-01-10'],
+                ['data1', 50, 56, 75],
+                ['data2', 2, 2, 2]
+            ];
+            args = createArgs(data);
+            expect(true).toBeTruthy();
+        });
+
+        it('should calculate bar width using tick count when there are more ticks than x axis values', function () {
+            expect(getBarWidth('data2', '0')).toEqual(34);
+        });
+
+        it('should set arguments with more unique x values than fit false ticks', function () {
+            var data = [
+                ['x', '2016-01-05', '2016-01-06','2016-01-07', '2016-01-08', '2016-01-09',
+                '2016-01-10', '2016-01-11','2016-01-12', '2016-01-13', '2016-01-14',
+                '2016-01-15', '2016-01-16', '2016-01-17','2016-01-18', '2016-01-19'],
+                ['data1', 50, 56, 75, null, null, null, 50, 56, 75, 50, 56, 75, 50, 56, 75],
+                ['data2', 2, 2, 2, null, null, null, 2, 2, 2, 50, 56, 75, 2, 2, 2]
+            ];
+            args = createArgs(data);
+            expect(true).toBeTruthy();
+        });
+
+        it('should calculate bar width using unique x value count when there are more x values than ticks', function () {
+            expect(getBarWidth('data2', '0')).toEqual(18);
         });
     });
 });

--- a/src/axis.js
+++ b/src/axis.js
@@ -330,14 +330,15 @@ c3_axis_internal_fn.generateAxis = function () {
     axis.tickOffset = function () {
         return internal.tickOffset;
     };
-    axis.tickInterval = function (tickCount) {
+    axis.tickInterval = function (maxUniqueXValues) {
         var interval, length;
         if (params.isCategory) {
             interval = internal.tickOffset * 2;
         }
         else {
             length = axis.g.select('path.domain').node().getTotalLength() - internal.outerTickSize * 2;
-            var intervalDivisor = tickCount || axis.g.selectAll('line').size();
+            var tickCount = axis.g.selectAll('line').size();
+            var intervalDivisor = Math.max(maxUniqueXValues, tickCount) || tickCount;
             interval = length / intervalDivisor;
         }
         return interval === Infinity ? 0 : interval;

--- a/src/axis.js
+++ b/src/axis.js
@@ -330,14 +330,15 @@ c3_axis_internal_fn.generateAxis = function () {
     axis.tickOffset = function () {
         return internal.tickOffset;
     };
-    axis.tickInterval = function () {
+    axis.tickInterval = function (tickCount) {
         var interval, length;
         if (params.isCategory) {
             interval = internal.tickOffset * 2;
         }
         else {
             length = axis.g.select('path.domain').node().getTotalLength() - internal.outerTickSize * 2;
-            interval = length / axis.g.selectAll('line').size();
+            var intervalDivisor = tickCount || axis.g.selectAll('line').size();
+            interval = length / intervalDivisor;
         }
         return interval === Infinity ? 0 : interval;
     };

--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -52,8 +52,14 @@ c3_chart_internal_fn.redrawBar = function (drawBar, withTransition) {
     ];
 };
 c3_chart_internal_fn.getBarW = function (axis, barTargetsNum) {
-    var $$ = this, config = $$.config,
-        w = typeof config.bar_width === 'number' ? config.bar_width : barTargetsNum ? (axis.tickInterval() * config.bar_width_ratio) / barTargetsNum : 0;
+    var $$ = this, config = $$.config, maxUniqueXValues;
+    if ($$.data.targets.length > 0) {
+        maxUniqueXValues = $$.data.targets.reduce(function returnMaxLength(maxLength, target) {
+            var targetLength = target.values.length;
+            return Math.max(maxLength, targetLength);
+        }, 0);
+    }
+    var w = typeof config.bar_width === 'number' ? config.bar_width : barTargetsNum ? (axis.tickInterval(maxUniqueXValues) * config.bar_width_ratio) / barTargetsNum : 0;
     return config.bar_width_max && w > config.bar_width_max ? config.bar_width_max : w;
 };
 c3_chart_internal_fn.getBars = function (i, id) {


### PR DESCRIPTION
Partial fix for issue #1386 

If tick fit is set to false and there are many values, the bars overlap because the bar width is currently calculated based on how many ticks there are instead of the data points.