### PR TITLE
Fix examples (D3 version updates)

### DIFF
--- a/extensions/chart-bubble/index.html
+++ b/extensions/chart-bubble/index.html
@@ -5,7 +5,7 @@
   <body>
     <div id="chart"></div>
 
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="http://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <script src="c3.min.js"></script>
     <script src="bubble.js"></script>
     <script>

--- a/htdocs/js/samples/requirejs.js
+++ b/htdocs/js/samples/requirejs.js
@@ -1,7 +1,7 @@
 require.config({
     baseUrl: '/js',
     paths: {
-        d3: "http://d3js.org/d3.v3.min"
+        d3: "http://d3js.org/d3.v4.min"
     }
 });
 

--- a/htdocs/samples/api_category.html
+++ b/htdocs/samples/api_category.html
@@ -6,7 +6,7 @@
     <div id="chart"></div>
     <div id="message"></div>
 
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="http://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <script src="/js/c3.js"></script>
     <script>
 

--- a/htdocs/samples/axes_x_localtime.html
+++ b/htdocs/samples/axes_x_localtime.html
@@ -5,7 +5,7 @@
   <body>
     <div id="chart"></div>
 
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="http://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <script src="/js/c3.js"></script>
     <script>
 

--- a/htdocs/samples/chart_step_category.html
+++ b/htdocs/samples/chart_step_category.html
@@ -5,7 +5,7 @@
   <body>
     <div id="chart"></div>
 
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="http://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <script src="/js/c3.js"></script>
     <script>
       var chart = c3.generate({

--- a/htdocs/samples/plugin.html
+++ b/htdocs/samples/plugin.html
@@ -5,8 +5,7 @@
   <body>
     <div id="chart"></div>
 
-<!--    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>-->
-    <script src="/js/d3.min.js" charset="utf-8"></script>
+    <script src="http://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <script src="/js/c3.js"></script>
     <script src="/js/samples/plugin.js"></script>
     <script>

--- a/htdocs/samples/zoom_reduction.html
+++ b/htdocs/samples/zoom_reduction.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>c3ext</title>
@@ -7,7 +7,7 @@
     <link href="/css/c3.css" rel="stylesheet" />
     <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
     <script src="https://rawgithub.com/brandonaaron/jquery-mousewheel/master/jquery.mousewheel.min.js"></script>
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="http://d3js.org/d3.v4.min.js" charset="utf-8"></script>
     <script src="/js/c3.js"></script>
     <script src="/js/extensions/c3ext.js"></script>
     <script src="/js/samples/zoom_reduction.js"></script>
@@ -18,7 +18,7 @@
         <h2>Hackathon May 2014</h2>
         <h4>By Dan-el Khen</h4>
         <p>Rendering graphs in the browser has many advantages, the downside is that takes a long time to render when having large datasets. </p>
-        <p>This feature allows you reduces the dataset according to your current zoom level. 
+        <p>This feature allows you reduces the dataset according to your current zoom level.
         It allows the developer to implement the reduction algorithm in a simple function that accepts an array of values, and returns a reduced single value.
         The default reducer will take the first item, but avg/sum/first/last or any other algorithm is simple to implement.
         </p>


### PR DESCRIPTION
C3 started depending on D3 v4 since #2246. Some examples still loads D3 v3 and become broken. This PR updates those dependencies.