### PR TITLE
Update D3 deps in getting started guide

### DIFF
--- a/docs/gettingstarted.html.haml
+++ b/docs/gettingstarted.html.haml
@@ -42,7 +42,7 @@
                 <span class="tag">&lt;<span class="title">link</span> <span class="attribute">href</span>=<span class="value">"/path/to/c3.css"</span> <span class="attribute">rel</span>=<span class="value">"stylesheet"</span>&gt;</span>
 
                 <span class="comment">&lt;!-- Load d3.js and c3.js --&gt;</span>
-                <span class="tag">&lt;<span class="title">script</span> <span class="attribute">src</span>=<span class="value">"/path/to/d3.v3.min.js"</span> <span class="attribute">charset</span>=<span class="value">"utf-8"</span>&gt;</span><span class="tag">&lt;/<span class="title">script</span>&gt;</span>
+                <span class="tag">&lt;<span class="title">script</span> <span class="attribute">src</span>=<span class="value">"/path/to/d3.v4.min.js"</span> <span class="attribute">charset</span>=<span class="value">"utf-8"</span>&gt;</span><span class="tag">&lt;/<span class="title">script</span>&gt;</span>
                 <span class="tag">&lt;<span class="title">script</span> <span class="attribute">src</span>=<span class="value">"/path/to/c3.min.js"</span>&gt;</span><span class="tag">&lt;/<span class="title">script</span>&gt;</span>
 
         %p C3 depends on D3, so please load D3 too.
@@ -86,7 +86,7 @@
                 require.config({
                   baseUrl: '/js',
                   paths: {
-                    d3: "http://d3js.org/d3.v3.min"
+                    d3: "http://d3js.org/d3.v4.min"
                   }
                 });
 


### PR DESCRIPTION
- C3 depends on D3 ^4.12.0 since v0.5.0.
- getting started guide still shows D3 v3 as dependency.
- This PR updates it.

---
close #2326