### PR TITLE
The zoom() getter now correctly returns current domain

### DIFF
--- a/spec/api.zoom-spec.js
+++ b/spec/api.zoom-spec.js
@@ -24,6 +24,14 @@ describe('c3 api zoom', function () {
             };
         });
 
+        it('should return the correct extent', function () {
+            var zoomDomain = chart.zoom(),
+                expectedDomain = chart.internal.x.domain();
+
+            expect(+zoomDomain[0]).toBe(+expectedDomain[0]);
+            expect(+zoomDomain[1]).toBe(+expectedDomain[1]);
+        });
+
         it('should be zoomed properly', function () {
             var target = [3, 5], domain;
             chart.zoom(target);

--- a/src/api.zoom.js
+++ b/src/api.zoom.js
@@ -15,8 +15,10 @@ c3_chart_fn.zoom = function (domain) {
             $$.redraw({withY: $$.config.zoom_rescale, withSubchart: false});
         }
         $$.config.zoom_onzoom.call(this, $$.x.orgDomain());
+        return domain;
+    } else {
+        return $$.x.domain();
     }
-    return domain;
 };
 c3_chart_fn.zoom.enable = function (enabled) {
     var $$ = this.internal;


### PR DESCRIPTION
This fix is copied from #2270 by @robhybrid.

Closes #1497