### PR TITLE
Modified home page in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "c3.css",
     "c3.js"
   ],
-  "homepage": "https://github.com/masayuki0812/c3",
+  "homepage": "https://github.com/c3js/c3",
   "authors": [
     "Masayuki Tanaka <masayuki0812@mac.com>"
   ],


### PR DESCRIPTION
Not sure, maybe not related, but at least not synchronized with info in package.json.

I'm haiving troubles with fetching c3 0.4.11 and it tells me:

```
$ bower install
bower c3#0.4.11             not-cached https://github.com/masayuki0812/c3.git#0.4.11
bower c3#0.4.11                resolve https://github.com/masayuki0812/c3.git#0.4.11
bower c3#0.4.11               checkout 0.4.11
TypeError: LRU: key must be a string or number. Almost certainly a bug! undefined
    at typeCheckKey (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\lru-cache\lib\lru-cache.js:20:19)
    at LRUCache.get (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\lru-cache\lib\lru-cache.js:230:3)
    at C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\lib\core\resolvers\GitRemoteResolver.js:122:70
    at _fulfilled (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\q\q.js:854:54)
    at self.promiseDispatch.done (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\q\q.js:883:30)
    at Promise.promise.promiseDispatch (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\q\q.js:816:13)
    at C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\q\q.js:877:14
    at runSingle (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\q\q.js:137:13)
    at flush (C:\Users\andrii.lundiak\AppData\Roaming\npm\node_modules\bower\node_modules\q\q.js:125:13)
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
bower c3#0.4.11               resolved https://github.com/masayuki0812/c3.git#0.4.11
bower c3#0.4.11                install c3#0.4.11
```

And I thought, it might be related....
Not sure, maybe it's recent GitHib changes regarding SSH.
