### PR TITLE
Append mouse event nodes before chart elements

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -272,6 +272,9 @@ c3_chart_internal_fn.initWithData = function (data) {
     // Grid lines
     if (config.grid_lines_front) { $$.initGridLines(); }
 
+    // Cover whole with rects for events
+    $$.initEventRect();
+
     // Define g for chart
     $$.initChartElements();
 
@@ -280,9 +283,6 @@ c3_chart_internal_fn.initWithData = function (data) {
 
     // Set targets
     $$.updateTargets($$.data.targets);
-
-    // Cover whole with rects for events
-    $$.initEventRect();
 
     // Set default extent if defined
     if (config.axis_x_selection) { $$.brush.selectionAsValue($$.getDefaultSelection()); }


### PR DESCRIPTION
Mouse event nodes were appended last, which covered up the chart elements so that their events weren't firing correctly.

Fixes #2329 and #2354

