### PR TITLE
Add support for axis.x.tick.multilineMax

### DIFF
--- a/docs/reference.html.haml
+++ b/docs/reference.html.haml
@@ -79,6 +79,7 @@
           = partial :reference_menu_item, locals: { id: 'axis.x.tick.rotate' }
           = partial :reference_menu_item, locals: { id: 'axis.x.tick.outer' }
           = partial :reference_menu_item, locals: { id: 'axis.x.tick.multiline' }
+          = partial :reference_menu_item, locals: { id: 'axis.x.tick.multilineMax' }
           = partial :reference_menu_item, locals: { id: 'axis.x.tick.width' }
           = partial :reference_menu_item, locals: { id: 'axis.x.max' }
           = partial :reference_menu_item, locals: { id: 'axis.x.min' }
@@ -1668,6 +1669,27 @@
               &nbsp;&nbsp;x: {
               &nbsp;&nbsp;&nbsp;&nbsp;tick: {
               &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiline: true
+              &nbsp;&nbsp;&nbsp;}
+              &nbsp;&nbsp;}
+              }
+      %hr
+
+      %section
+        %h3
+          = partial :reference_item_link, locals: { id: 'axis.x.tick.multilineMax' }
+        %p If this option is set and is above <code>0</code>, the number of lines will be adjusted to less than this value and tick's text is ellipsified.
+        %br
+        %h5 Default:
+        <code>0</code>
+        %h5 Format:
+        %div.sourcecode
+          %pre
+            %code.html.javascript
+              axis: {
+              &nbsp;&nbsp;x: {
+              &nbsp;&nbsp;&nbsp;&nbsp;tick: {
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiline: true,
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multilineMax: 2,
               &nbsp;&nbsp;&nbsp;}
               &nbsp;&nbsp;}
               }

--- a/docs/reference.html.haml
+++ b/docs/reference.html.haml
@@ -1655,7 +1655,22 @@
       %section
         %h3
           = partial :reference_item_link, locals: { id: 'axis.x.tick.multiline' }
-        %p not yet
+        %p Enable multiline.
+        %br
+        %p If this option is set <code>true</code>, when a tick's text on the x-axis is too long, it splits the text into multiple lines in order to avoid text overlapping.
+        %h5 Default:
+        <code>false</code>
+        %h5 Format:
+        %div.sourcecode
+          %pre
+            %code.html.javascript
+              axis: {
+              &nbsp;&nbsp;x: {
+              &nbsp;&nbsp;&nbsp;&nbsp;tick: {
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiline: true
+              &nbsp;&nbsp;&nbsp;}
+              &nbsp;&nbsp;}
+              }
       %hr
 
       %section

--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -542,13 +542,11 @@ describe('c3 chart axis', function () {
                     });
                 });
 
-                describe('with multiline.max', function() {
+                describe('with multilineMax', function() {
                     beforeAll(function() {
                         args.axis.x.tick = {
-                            multiline: {
-                                enabled: true,
-                                max: 2,
-                            }
+                            multiline: true,
+                            multilineMax: 2,
                         };
                     });
 

--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -541,6 +541,33 @@ describe('c3 chart axis', function () {
                         });
                     });
                 });
+
+                describe('with multiline.max', function() {
+                    beforeAll(function() {
+                        args.axis.x.tick = {
+                            multiline: {
+                                enabled: true,
+                                max: 2,
+                            }
+                        };
+                    });
+
+                    it('should ellipsify x tick properly', function() {
+                        var tick = chart.internal.main.select('.c3-axis-x').select('g.tick');
+                        var tspans = tick.selectAll('tspan');
+                        var expectedTickText = [
+                            'this is a very long',
+                            'tick text on categ...',
+                        ];
+
+                        expect(tspans.size()).toBe(2);
+
+                        tspans.each(function (d, i) {
+                            var tspan = d3.select(this);
+                            expect(tspan.text()).toBe(expectedTickText[i]);
+                        });
+                    });
+                });
             });
         });
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -446,8 +446,8 @@ c3_axis_fn.getXAxis = function getXAxis(scale, orient, tickFormat, tickValues, w
         axisParams = {
             isCategory: $$.isCategorized(),
             withOuterTick: withOuterTick,
-            tickMultiline: typeof config.axis_x_tick_multiline === 'object' ? Boolean(config.axis_x_tick_multiline.enabled) : config.axis_x_tick_multiline,
-            tickMultilineMax: typeof config.axis_x_tick_multiline === 'object' ? Number(config.axis_x_tick_multiline.max) : 0,
+            tickMultiline: config.axis_x_tick_multiline,
+            tickMultilineMax: config.axis_x_tick_multiline ? Number(config.axis_x_tick_multilineMax) : 0,
             tickWidth: config.axis_x_tick_width,
             tickTextRotate: withoutRotateTickText ? 0 : config.axis_x_tick_rotate,
             withoutTransition: withoutTransition,

--- a/src/axis.js
+++ b/src/axis.js
@@ -108,6 +108,11 @@ c3_axis_internal_fn.isVertical = function () {
 c3_axis_internal_fn.tspanData = function (d, i, scale) {
     var internal = this;
     var splitted = internal.params.tickMultiline ? internal.splitTickText(d, scale) : [].concat(internal.textFormatted(d));
+
+    if (internal.params.tickMultiline && internal.params.tickMultilineMax > 0) {
+        splitted = internal.ellipsify(splitted, internal.params.tickMultilineMax);
+    }
+
     return splitted.map(function (s) {
         return { index: i, splitted: s, length: splitted.length };
     });
@@ -146,6 +151,27 @@ c3_axis_internal_fn.splitTickText = function (d, scale) {
     }
 
     return split(splitted, tickText + "");
+};
+c3_axis_internal_fn.ellipsify = function(splitted, max) {
+    if (splitted.length <= max) {
+        return splitted;
+    }
+
+    var ellipsified = splitted.slice(0, max);
+    var remaining = 3;
+    for (var i = max-1 ; i >= 0 ; i--) {
+        var available = ellipsified[i].length;
+
+        ellipsified[i] = ellipsified[i].substr(0, available-remaining).padEnd(available, '.');
+
+        remaining -= available;
+
+        if (remaining <= 0) {
+            break;
+        }
+    }
+
+    return ellipsified;
 };
 c3_axis_internal_fn.updateTickLength = function () {
     var internal = this;
@@ -420,7 +446,8 @@ c3_axis_fn.getXAxis = function getXAxis(scale, orient, tickFormat, tickValues, w
         axisParams = {
             isCategory: $$.isCategorized(),
             withOuterTick: withOuterTick,
-            tickMultiline: config.axis_x_tick_multiline,
+            tickMultiline: typeof config.axis_x_tick_multiline === 'object' ? Boolean(config.axis_x_tick_multiline.enabled) : config.axis_x_tick_multiline,
+            tickMultilineMax: typeof config.axis_x_tick_multiline === 'object' ? Number(config.axis_x_tick_multiline.max) : 0,
             tickWidth: config.axis_x_tick_width,
             tickTextRotate: withoutRotateTickText ? 0 : config.axis_x_tick_rotate,
             withoutTransition: withoutTransition,

--- a/src/config.js
+++ b/src/config.js
@@ -107,6 +107,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         axis_x_tick_rotate: 0,
         axis_x_tick_outer: true,
         axis_x_tick_multiline: true,
+        axis_x_tick_multiline_max: 0,
         axis_x_tick_width: null,
         axis_x_max: undefined,
         axis_x_min: undefined,

--- a/src/config.js
+++ b/src/config.js
@@ -107,7 +107,7 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         axis_x_tick_rotate: 0,
         axis_x_tick_outer: true,
         axis_x_tick_multiline: true,
-        axis_x_tick_multiline_max: 0,
+        axis_x_tick_multilineMax: 0,
         axis_x_tick_width: null,
         axis_x_max: undefined,
         axis_x_min: undefined,

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -871,4 +871,25 @@ if (!Function.prototype.bind) {
     }
 }());
 
+// String.padEnd polyfill for IE11
+//
+// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
+if (!String.prototype.padEnd) {
+    String.prototype.padEnd = function padEnd(targetLength,padString) {
+        targetLength = targetLength>>0; //floor if number or convert non-number to 0;
+        padString = String((typeof padString !== 'undefined' ? padString : ' '));
+        if (this.length > targetLength) {
+            return String(this);
+        }
+        else {
+            targetLength = targetLength-this.length;
+            if (targetLength > padString.length) {
+                padString += padString.repeat(targetLength/padString.length); //append to original to ensure we are longer than needed
+            }
+            return String(this) + padString.slice(0,targetLength);
+        }
+    };
+}
+
 /* jshint ignore:end */


### PR DESCRIPTION
**Summary**:
If you have long category names you can use `axis.x.tick.multiline` to make  these names render properly into multiple lines. A problem arises when category names have variable lengths and your chart has a fixed height, you'll then start seeing these names being cut off.

On this PR I'm adding support for a way to define the maximum amount of lines supported on a given chart through a new optional config flag: `axis.x.tick.multilineMax`.

**Documentation**:
![screen shot 2018-05-16 at 3 19 39 pm](https://user-images.githubusercontent.com/712667/40147021-bd6372b2-591c-11e8-9def-705930a1476c.png)

**Examples**:
![c3js__x_axis_multiline_max__enabled_](https://user-images.githubusercontent.com/712667/39896269-53b1a618-5462-11e8-8fe1-9b011d62ef6c.png)
https://codepen.io/jcsmorais/pen/KRorNQ

![c3js__x_axis_multiline_max__disabled_](https://user-images.githubusercontent.com/712667/39896270-54dc38d2-5462-11e8-9231-44792eeaaea4.png)
https://codepen.io/jcsmorais/pen/demQgM

**Related issues**:
* https://github.com/c3js/c3/issues/916
* https://github.com/c3js/c3/issues/2309
* https://github.com/c3js/c3/issues/2341
* https://github.com/c3js/c3/issues/2346

**Notes**:
1. ~~Struggled a bit with adding tests and figuring out how these are organized, figured I'd get feedback first and I'll try to add these later.~~ Edit: kept struggling to add test cases mostly due to the nested describes that rely on data set by their parents, which imho doesn't make it easy to understand what's going on, nor what what the data dependencies are, plus it makes it hard to run specific test cases in isolation. Maybe that's something that would be worth investing time on? Either way, I was able to add a test case to confirm the expected behavior. 
2. ~~Wasn't able to add documentation, kept getting some errors while running `npm run build:docs`.~~ Edit: documentation added for both `x.axis.tick.multiline` and `x.axis.tick.multilineMax`.