### PR TITLE
Allow the graph to follow the container vertical resize

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -827,8 +827,6 @@ c3_chart_internal_fn.updateSvgSize = function () {
     $$.svg.select('#' + $$.clipIdForSubchart).select('rect')
         .attr('width', $$.width)
         .attr('height', brush.size() ? brush.attr('height') : 0);
-    // MEMO: parent div's height will be bigger than svg when <!DOCTYPE html>
-    $$.selectChart.style('max-height', $$.currentHeight + "px");
 };
 
 


### PR DESCRIPTION
Hello,

- C3 efab2ea85feb3fd33fab6700d7e45546da1f127c (latest master)
- D3 v5 (5.4.0)
- Tested browsers: latest chrome, latest safari, latest FF and IE11

Observed behavior:
When changing the vertical window size the chart only updates towards
smaller height (can only shrink). When the window is getting higher, the chart
stays at the last height. The horizontal resizing works as expected.

This is CodePen (couldn't reproduce it using jsFiddle) of the original C3:

https://codepen.io/anon/pen/aGewNy

This is CodePen with the fix applied:

https://codepen.io/anon/pen/qYejZp

Please drag the horizontal bar up and down and observe how chart follows the resizing.

regards,

jarek