### PR TITLE
fix step-before and step-after with dedicated test (#2340)

### DIFF
--- a/spec/shape.line-spec.js
+++ b/spec/shape.line-spec.js
@@ -20,7 +20,12 @@ describe('c3 chart shape line', function () {
                         ['data3', -150, 120, 110, 140, 115, 125]
                     ],
                     type: 'line'
-                }
+                },
+				line: {
+					step: {
+					  type: 'step'
+					}
+				}
             };
         });
 
@@ -51,7 +56,31 @@ describe('c3 chart shape line', function () {
                     expect(style).toBe('crispedges');
                 });
             });
-        });
+		});
+		
+		describe('should change to step chart with step-after', function () {
+			beforeAll(function(){
+				args.line.step.type = 'step-after';
+			});
+			it("should have shape-rendering = crispedges when it's step chart", function () {
+				d3.selectAll('.c3-line').each(function () {
+					var style = d3.select(this).style('shape-rendering').toLowerCase();
+					expect(style).toBe('crispedges');
+				});
+			});
+		});
+
+		describe('should change to step chart with step-before', function () {
+			beforeAll(function(){
+				args.line.step.type = 'step-before';
+			});
+			it("should have shape-rendering = crispedges when it's step chart", function () {
+				d3.selectAll('.c3-line').each(function () {
+					var style = d3.select(this).style('shape-rendering').toLowerCase();
+					expect(style).toBe('crispedges');
+				});
+			});
+		});
 
         describe('should change to spline chart', function () {
             beforeAll(function(){

--- a/src/shape.js
+++ b/src/shape.js
@@ -93,6 +93,8 @@ c3_chart_internal_fn.getInterpolate = function (d) {
             'cardinal-closed': d3.curveCardinalClosed,
             'monotone': d3.curveMonotoneX,
             'step': d3.curveStep,
+			'step-before': d3.curveStepBefore,
+			'step-after': d3.curveStepAfter
         },
         type;
 


### PR DESCRIPTION
Hi all 

I request approval for this pull request for resolve the #2340 bug int he step chart with restore the "step-before" and "step-after" in the stop type graph.

I created a basic test for check if the graph works fine.
All test for my point of view are correctly ( I modify marginally the code of the graph).

For more usefull test I create two jsfiddle test
d3: v4.13.0 - [https://jsfiddle.net/xjy7r25w/](https://jsfiddle.net/xjy7r25w/)
d3: v5.4.0 - [https://jsfiddle.net/p0qe247m/](https://jsfiddle.net/p0qe247m/)

Please accept this pull request.

Thanks
Lorenzo
