### PR TITLE
Stop sending status from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,2 @@
 coverage:
-  status:
-    project:
-      default:
-        threshold: 0.4
-    patch: no
-    change: no
+  status: no


### PR DESCRIPTION
because codecov status is not such useful for this project.
