### PR TITLE
Store artifact of docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - store_artifacts:
           path: htdocs
           destination: htdocs
-  publish-docs:
+  docs:
     docker:
       - image: circleci/ruby:2.4-node
         env:
@@ -45,17 +45,15 @@ jobs:
           paths:
             - ./node_modules
 
-      - run: npm run publish-docs
+      - run: npm run build
+      - run: npm run copy-to-docs
+      - run: npm run build:docs
+      - store_artifacts:
+          path: build
+          destination: docs
 workflows:
   version: 2
   test:
     jobs:
       - test
-  publish-docs:
-    jobs:
-      - publish-docs:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+      - docs


### PR DESCRIPTION
This PR is the second part of #2426.

This PR
- stops publishing the doc site from circle ci (now which is being published from travis ci)
- instead stores the doc site as artifact on circle ci
