### PR TITLE
chore: publish necessary files only

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.yml]
 indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.6.6",
   "description": "D3-based reusable chart library",
   "main": "c3.js",
+  "files": [
+    "c3.js",
+    "c3.min.js",
+    "c3.css",
+    "c3.min.css"
+  ],
   "scripts": {
     "start": "static -p 8080 htdocs/",
     "lint": "jshint --reporter=node_modules/jshint-stylish src/ spec/",


### PR DESCRIPTION
package.json's `files` property works as a whitelist for publishing https://docs.npmjs.com/files/package.json#files
