### PR TITLE
Add zoom type 'drag' option (based on #1500)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ components
 
 # coverage report
 /coverage
+
+# OS related
+.DS_Store
+
+# IDE related
+.idea
+

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -374,6 +374,9 @@
               <a href="./samples/zoom_type.html">
                 Change Zoom Type
               </a>
+              <a href="./samples/zoom_type_disable_default_behavior.html">
+                Zoom Types with disableDefaultBehavior: true
+              </a>
               <a href="./samples/zoom_category.html">
                 Zoom on category axis
               </a>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -371,6 +371,9 @@
               <a href="./samples/zoom.html">
                 Enable zoom
               </a>
+              <a href="./samples/zoom_type.html">
+                Change Zoom Type
+              </a>
               <a href="./samples/zoom_category.html">
                 Zoom on category axis
               </a>

--- a/htdocs/samples/zoom_type.html
+++ b/htdocs/samples/zoom_type.html
@@ -1,0 +1,62 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="/css/c3.css">
+  </head>
+  <body>
+    <p>Zoom Type Scroll with Default Zoom Behavior</p>
+    <div id="chart1"></div>
+
+    <p>Zoom Type Drag with Default Zoom Behavior</p>
+    <div id="chart2"></div>
+
+    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="/js/c3.js"></script>
+    <script>
+
+      var chart1 = c3.generate({
+          bindto: '#chart1',
+          data: {
+              columns: [
+                  generateData(100)
+              ]
+          },
+          zoom: {
+              enabled: true,
+              type: 'scroll',
+              disableDefaultBehavior: false
+          }
+      });
+
+      var chart2 = c3.generate({
+          bindto: '#chart2',
+          data: {
+              columns: [
+                  generateData(100)
+              ]
+          },
+          zoom: {
+              enabled: true,
+              type: 'drag',
+              disableDefaultBehavior: false
+          }
+      });
+
+      function load() {
+        chart1.load({
+          columns: [
+            generateData(Math.random() * 1000)
+          ]
+        });
+      }
+
+      function generateData(n) {
+        var column = ['sample'];
+        for (var i = 0; i < n; i++) {
+          column.push(Math.random() * 500);
+        }
+        return column;
+      }
+
+    </script>
+  </body>
+</html>

--- a/htdocs/samples/zoom_type.html
+++ b/htdocs/samples/zoom_type.html
@@ -22,8 +22,7 @@
           },
           zoom: {
               enabled: true,
-              type: 'scroll',
-              disableDefaultBehavior: false
+              type: 'scroll'
           }
       });
 
@@ -36,8 +35,7 @@
           },
           zoom: {
               enabled: true,
-              type: 'drag',
-              disableDefaultBehavior: false
+              type: 'drag'
           }
       });
 

--- a/htdocs/samples/zoom_type.html
+++ b/htdocs/samples/zoom_type.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="/css/c3.css">
+    <link rel="stylesheet" type="text/css" href="../css/c3.css">
   </head>
   <body>
     <p>Zoom Type Scroll with Default Zoom Behavior</p>
@@ -9,8 +9,8 @@
     <p>Zoom Type Drag with Default Zoom Behavior</p>
     <div id="chart2"></div>
 
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-    <script src="/js/c3.js"></script>
+    <script src="https://d3js.org/d3.v5.js" charset="utf-8"></script>
+    <script src="../js/c3.js"></script>
     <script>
 
       var chart1 = c3.generate({

--- a/htdocs/samples/zoom_type_disable_default_behavior.html
+++ b/htdocs/samples/zoom_type_disable_default_behavior.html
@@ -1,0 +1,66 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="../css/c3.css">
+  </head>
+  <body>
+    <p>Zoom Type Scroll with Zoom Behavior Disabled (See the console)</p>
+    <div id="chart1"></div>
+
+    <p>Zoom Type Drag with Zoom Behavior Disabled (See the console)</p>
+    <div id="chart2"></div>
+
+    <script src="https://d3js.org/d3.v5.js" charset="utf-8"></script>
+    <script src="../js/c3.js"></script>
+    <script>
+
+      var chart1 = c3.generate({
+          bindto: '#chart1',
+          data: {
+              columns: [
+                  generateData(100)
+              ]
+          },
+          zoom: {
+              enabled: true,
+              type: 'scroll',
+              disableDefaultBehavior: true,
+              onzoom: (d) => console.log(d),
+              onzoomend: (d) => console.log(d),
+          }
+      });
+
+      var chart2 = c3.generate({
+          bindto: '#chart2',
+          data: {
+              columns: [
+                  generateData(100)
+              ]
+          },
+          zoom: {
+              enabled: true,
+              type: 'drag',
+              disableDefaultBehavior: true,
+              onzoom: (d) => console.log(d),
+              onzoomend: (d) => console.log(d),
+          }
+      });
+
+      function load() {
+        chart1.load({
+          columns: [
+            generateData(Math.random() * 1000)
+          ]
+        });
+      }
+
+      function generateData(n) {
+        var column = ['sample'];
+        for (var i = 0; i < n; i++) {
+          column.push(Math.random() * 500);
+        }
+        return column;
+      }
+
+    </script>
+  </body>
+</html>

--- a/src/class.js
+++ b/src/class.js
@@ -22,6 +22,7 @@ export default {
     eventRectsMultiple: 'c3-event-rects-multiple',
     zoomRect: 'c3-zoom-rect',
     brush: 'c3-brush',
+    dragZoom: 'c3-drag-zoom',
     focused: 'c3-focused',
     defocused: 'c3-defocused',
     region: 'c3-region',

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ ChartInternal.prototype.getDefaultConfig = function () {
         zoom_enabled: false,
         zoom_initialRange: undefined,
         zoom_type: 'scroll',
+        zoom_disableDefaultBehavior: false,
         zoom_privileged: false,
         zoom_rescale: false,
         zoom_onzoom: function () {},

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,8 @@ ChartInternal.prototype.getDefaultConfig = function () {
         resize_auto: true,
         zoom_enabled: false,
         zoom_initialRange: undefined,
+        zoom_type: 'scroll',
+        zoom_disableDefaultBehavior: false,
         zoom_privileged: false,
         zoom_rescale: false,
         zoom_onzoom: function () {},

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,6 @@ ChartInternal.prototype.getDefaultConfig = function () {
         zoom_enabled: false,
         zoom_initialRange: undefined,
         zoom_type: 'scroll',
-        zoom_disableDefaultBehavior: false,
         zoom_privileged: false,
         zoom_rescale: false,
         zoom_onzoom: function () {},

--- a/src/core.js
+++ b/src/core.js
@@ -257,6 +257,9 @@ ChartInternal.prototype.initWithData = function(data) {
     if ($$.initPie) {
         $$.initPie();
     }
+    if ($$.initDragZoom) {
+        $$.initDragZoom();
+    }
     if ($$.initSubchart) {
         $$.initSubchart();
     }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -61,3 +61,7 @@
 /*-- Arc --*/
 
 @import 'arc';
+
+/*-- Zoom --*/
+
+@import 'zoom';

--- a/src/scss/zoom.scss
+++ b/src/scss/zoom.scss
@@ -1,0 +1,13 @@
+.c3-drag-zoom.enabled{
+  pointer-events: all!important;
+  visibility: visible;
+}
+
+.c3-drag-zoom.disabled{
+    pointer-events: none!important;
+    visibility: hidden;
+}
+
+.c3-drag-zoom .extent {
+    fill-opacity: .1;
+}

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -23,9 +23,7 @@ ChartInternal.prototype.initZoom = function () {
             var e = d3.event.sourceEvent;
             if (e && e.type === "brush") { return; }
 
-            if (!config.zoom_disableDefaultBehavior) {
-                $$.redrawForZoom.call($$);
-            }
+            $$.redrawForZoom();
 
             config.zoom_onzoom.call($$.api, $$.x.orgDomain());
         })
@@ -136,9 +134,14 @@ ChartInternal.prototype.redrawForZoom = function () {
 
     zoom.update();
 
+    if (config.zoom_disableDefaultBehavior) {
+        return;
+    }
+
     if ($$.isCategorized() && x.orgDomain()[0] === $$.orgXDomain[0]) {
         x.domain([$$.orgXDomain[0] - 1e-10, x.orgDomain()[1]]);
     }
+
     $$.redraw({
         withTransition: false,
         withY: config.zoom_rescale,
@@ -146,6 +149,7 @@ ChartInternal.prototype.redrawForZoom = function () {
         withEventRect: false,
         withDimension: false
     });
+
     if (d3.event.sourceEvent && d3.event.sourceEvent.type === 'mousemove') {
         $$.cancelClick = true;
     }

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -73,6 +73,8 @@ ChartInternal.prototype.initDragZoom = function () {
         return;
     }
 
+    const getZoomedDomain = selection => selection && selection.map(x => $$.x.invert(x))
+
     const brush = $$.dragZoomBrush = d3.brushX()
         .on("start", () => {
             $$.api.unzoom();
@@ -81,25 +83,25 @@ ChartInternal.prototype.initDragZoom = function () {
                 .select("." + CLASS.dragZoom)
                 .classed("disabled", false);
 
-            config.zoom_onzoomstart.call($$.api, $$.x.orgDomain());
+            config.zoom_onzoomstart.call($$.api, d3.event.sourceEvent);
         })
         .on("brush", () => {
-            config.zoom_onzoom.call($$.api, $$.x.orgDomain());
+            config.zoom_onzoom.call($$.api, getZoomedDomain(d3.event.selection));
         })
         .on("end", () => {
             if (d3.event.selection == null) {
                 return;
             }
 
-            const [x0, x1] = d3.event.selection;
+            const zoomedDomain = getZoomedDomain(d3.event.selection);
 
-            $$.api.zoom([$$.x.invert(x0), $$.x.invert(x1)]);
+            $$.api.zoom(zoomedDomain);
 
             $$.svg
                 .select("." + CLASS.dragZoom)
                 .classed("disabled", true);
 
-            config.zoom_onzoomstart.call($$.api, $$.x.orgDomain());
+            config.zoom_onzoomend.call($$.api, zoomedDomain);
         });
 
     context

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -62,16 +62,16 @@ ChartInternal.prototype.zoomTransform = function (range) {
 };
 
 ChartInternal.prototype.initDragZoom = function () {
-    if (!(this.config.zoom_type === 'drag' && this.config.zoom_enabled)) {
-        return;
-    }
-
     const $$ = this;
     const d3 = $$.d3;
     const config = $$.config;
     const context = $$.context = $$.svg;
     const brushXPos = $$.margin.left + 20.5;
     const brushYPos = $$.margin.top + 0.5;
+
+    if (!(config.zoom_type === 'drag' && config.zoom_enabled)) {
+        return;
+    }
 
     const brush = $$.dragZoomBrush = d3.brushX()
         .on("start", () => {
@@ -88,16 +88,12 @@ ChartInternal.prototype.initDragZoom = function () {
         })
         .on("end", () => {
             if (d3.event.selection == null) {
-                return
+                return;
             }
 
             const [x0, x1] = d3.event.selection;
 
-            if (!config.zoom_disableDefaultBehavior) {
-                $$.api.zoom([$$.x.invert(x0), $$.x.invert(x1)]);
-            } else {
-                $$.api.zoom([$$.x.invert(x0), $$.x.invert(x1)]);
-            }
+            $$.api.zoom([$$.x.invert(x0), $$.x.invert(x1)]);
 
             $$.svg
                 .select("." + CLASS.dragZoom)

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -22,7 +22,12 @@ ChartInternal.prototype.initZoom = function () {
 
             var e = d3.event.sourceEvent;
             if (e && e.type === "brush") { return; }
-            $$.redrawForZoom.call($$);
+
+            if (!config.zoom_disableDefaultBehavior) {
+                $$.redrawForZoom.call($$);
+            }
+
+            config.zoom_onzoom.call($$.api, $$.x.orgDomain());
         })
         .on('end', function () {
             if (config.zoom_type !== 'scroll') {
@@ -73,7 +78,7 @@ ChartInternal.prototype.initDragZoom = function () {
         return;
     }
 
-    const getZoomedDomain = selection => selection && selection.map(x => $$.x.invert(x))
+    const getZoomedDomain = selection => selection && selection.map(x => $$.x.invert(x));
 
     const brush = $$.dragZoomBrush = d3.brushX()
         .on("start", () => {
@@ -95,7 +100,9 @@ ChartInternal.prototype.initDragZoom = function () {
 
             const zoomedDomain = getZoomedDomain(d3.event.selection);
 
-            $$.api.zoom(zoomedDomain);
+            if (!config.zoom_disableDefaultBehavior) {
+              $$.api.zoom(zoomedDomain);
+            }
 
             $$.svg
                 .select("." + CLASS.dragZoom)
@@ -142,5 +149,4 @@ ChartInternal.prototype.redrawForZoom = function () {
     if (d3.event.sourceEvent && d3.event.sourceEvent.type === 'mousemove') {
         $$.cancelClick = true;
     }
-    config.zoom_onzoom.call($$.api, x.orgDomain());
 };


### PR DESCRIPTION
This PR is a continuation of #1500. #1500 is not mergeable because of d3's breaking changes and c3's refactoring. I did the following to fit the feature to the current code base.

- Rebased #1500 
- Updated d3 API calls to follow the breaking changes between v3 and v5 (and did some refactoring)
- removed disableDefaultBehavior config because I couldn't find the use case of `zoom.disableDefaultBahavior: true`

The preview of this change is available [here (circleci artifact)](https://468-11496279-gh.circle-artifacts.com/0/htdocs/samples/zoom_type.html)

@mistic 
Could you check if the above page's behavior reflects your original idea of the feature?