### PR TITLE
Remove Function.prototype.bind polyfill

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,31 +1,5 @@
 /* jshint ignore:start */
 
-// PhantomJS doesn't have support for Function.prototype.bind, which has caused confusion. Use
-// this polyfill to avoid the confusion.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill
-
-if (!Function.prototype.bind) {
-    Function.prototype.bind = function (oThis) {
-        if (typeof this !== 'function') {
-            // closest thing possible to the ECMAScript 5
-            // internal IsCallable function
-            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-        }
-
-        var aArgs = Array.prototype.slice.call(arguments, 1),
-            fToBind = this,
-            fNOP = function () {},
-            fBound = function () {
-                return fToBind.apply(this instanceof fNOP ? this : oThis, aArgs.concat(Array.prototype.slice.call(arguments)));
-            };
-
-        fNOP.prototype = this.prototype;
-        fBound.prototype = new fNOP();
-
-        return fBound;
-    };
-}
-
 // SVGPathSeg API polyfill
 // https://github.com/progers/pathseg
 //


### PR DESCRIPTION
Because we don't use phantomjs anymore, I think this polyfill can be safely dropped.

cf. https://caniuse.com/#feat=es5