### PR TITLE
Change npm start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Additional samples can be found in this repository:
 
 You can run these samples as:
 ```
-$ npm start
+$ npm run serve-static
 ```
 
 ## Google Group

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "c3.min.css"
   ],
   "scripts": {
-    "start": "static -p 8080 htdocs/",
+    "start": "run-p serve-static watch",
+    "serve-static": "static -p 8080 htdocs/",
     "lint": "jshint --reporter=node_modules/jshint-stylish src/ spec/",
     "docs": "bundle exec middleman",
     "build": "run-s build:js build:css",


### PR DESCRIPTION
- now `npm start` starts the watch process as well as the sample server.
- `npm run serve-static` starts the sample server.