### PR TITLE
index parameter in tooltip.format.title #2392

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -131,7 +131,7 @@ ChartInternal.prototype.getTooltipContent = function (d, defaultTitleFormat, def
         }
 
         if (!text) {
-            title = sanitise(titleFormat ? titleFormat(d[i].x) : d[i].x);
+          title = sanitise(titleFormat ? titleFormat(d[i].x, d[i].index) : d[i].x);
             text = "<table class='" + $$.CLASS.tooltip + "'>" + (title || title === 0 ? "<tr><th colspan='2'>" + title + "</th></tr>" : "");
         }
 


### PR DESCRIPTION
## Title

Tooltip title format function is passed index

## Description

Resolves #2392

## Commit message

The tooltip title format function now gets the x-value as well as the index of the active point.