### PR TITLE
Position middle and center interchangeable

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -220,9 +220,9 @@ Axis.prototype.textForY2AxisLabel = function textForY2AxisLabel() {
 Axis.prototype.xForAxisLabel = function xForAxisLabel(forHorizontal, position) {
     var $$ = this.owner;
     if (forHorizontal) {
-        return position.isLeft ? 0 : position.isCenter ? $$.width / 2 : $$.width;
+        return position.isLeft ? 0 : position.isCenter || position.isMiddle ? $$.width / 2 : $$.width;
     } else {
-        return position.isBottom ? -$$.height : position.isMiddle ? -$$.height / 2 : 0;
+        return position.isBottom ? -$$.height : position.isMiddle || position.isCenter ? -$$.height / 2 : 0;
     }
 };
 Axis.prototype.dxForAxisLabel = function dxForAxisLabel(forHorizontal, position) {
@@ -234,9 +234,9 @@ Axis.prototype.dxForAxisLabel = function dxForAxisLabel(forHorizontal, position)
 };
 Axis.prototype.textAnchorForAxisLabel = function textAnchorForAxisLabel(forHorizontal, position) {
     if (forHorizontal) {
-        return position.isLeft ? 'start' : position.isCenter ? 'middle' : 'end';
+        return position.isLeft ? 'start' : position.isCenter || position.isMiddle ? 'middle' : 'end';
     } else {
-        return position.isBottom ? 'start' : position.isMiddle ? 'middle' : 'end';
+        return position.isBottom ? 'start' : position.isMiddle || position.isCenter ? 'middle' : 'end';
     }
 };
 Axis.prototype.xForXAxisLabel = function xForXAxisLabel() {


### PR DESCRIPTION
```forHorizontal``` decides whether the width or height should be used for positioning.  

This PR allows the use of ```center``` and ```middle``` interchangeably. This is beneficial when rotating a chart dynamically. 

My use case is a dynamically updated chart.  The existing distinction of ```middle``` vs ```center``` forces me to update label positioning when adjusting ```rotated```.  This PR removes the need to update multiple values.

```
 axis: {
        rotated: true, // or false
        x: {
            label: {
                text: 'X Label',
                position: 'outer-middle' // or 'outer-center'
            }
        },
        y: {
            label: {
                text: 'Y Label',
                position: 'outer-middle' // or 'outer-center'
            }
        }
    }
```