### PR TITLE
document spline interpolation type options

### DIFF
--- a/htdocs/samples/chart_spline.html
+++ b/htdocs/samples/chart_spline.html
@@ -18,7 +18,12 @@
             data1: 'spline',
             data2: 'spline'
           }
-        }
+        },
+        spline: {
+          interpolation: {
+            type: 'monotone', // 'cardinal' is default
+          },
+        },
       });
     </script>
   </body>


### PR DESCRIPTION
Options for the type of spline interpolation methods aren't documented -- or at least I couldn't find it in docs. Option was added with #1268

<!--

Thank you for contributing!

Please make sure to:
 
- provide tests with your code changes to ensure they are working as expected.
- not commit any of the distribution file (`c3.js`, `c3.css`, `c3.min.js`, `c3.min.css`).

-->
