### PR TITLE
Update updateSvgSize to be less fragile

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -903,7 +903,7 @@ ChartInternal.prototype.updateSvgSize = function() {
     var $$ = this,
         brush = $$.svg.select(".c3-brush .overlay");
     $$.svg.attr('width', $$.currentWidth).attr('height', $$.currentHeight);
-    $$.svg.selectAll(['#' + $$.clipId + ',#' + $$.clipIdForGrid]).select('rect')
+    $$.svg.selectAll('#' + $$.clipId + ',#' + $$.clipIdForGrid).select('rect')
         .attr('width', $$.width)
         .attr('height', $$.height);
     $$.svg.select('#' + $$.clipIdForXAxis).select('rect')

--- a/src/core.js
+++ b/src/core.js
@@ -903,7 +903,7 @@ ChartInternal.prototype.updateSvgSize = function() {
     var $$ = this,
         brush = $$.svg.select(".c3-brush .overlay");
     $$.svg.attr('width', $$.currentWidth).attr('height', $$.currentHeight);
-    $$.svg.selectAll(['#' + $$.clipId, '#' + $$.clipIdForGrid]).select('rect')
+    $$.svg.selectAll(['#' + $$.clipId + ',#' + $$.clipIdForGrid]).select('rect')
         .attr('width', $$.width)
         .attr('height', $$.height);
     $$.svg.select('#' + $$.clipIdForXAxis).select('rect')


### PR DESCRIPTION
I have been unable to find the culprit in our system, but something is killing the functionality that allows `d3Selection.selectAll(<array>)` on our platform. I have created a fork where I update the `.selectAll` to use the much more common form of a comma-separated string selector instead of the array of selectors