### PR TITLE
Fix levelColor generation and its call for gauges (#2324)

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -344,7 +344,7 @@ ChartInternal.prototype.redrawArc = function (duration, durationForExit, withTra
         }
         else {
             mainArcLabelLine
-                .style("fill", function (d) { return config.color_pattern.length > 0 ? $$.levelColor(d.data.values[0].value) : $$.color(d.data); })
+                .style("fill", function (d) { return $$.levelColor ? $$.levelColor(d.data.values[0].value) : $$.color(d.data); })
                 .style("display", config.gauge_labelLine_show ? "" : "none")
                 .each(function (d) {
                     var lineLength = 0, lineThickness = 2, x = 0, y = 0, transform = "";

--- a/src/color.js
+++ b/src/color.js
@@ -35,7 +35,7 @@ ChartInternal.prototype.generateLevelColor = function () {
         asValue = threshold.unit === 'value',
         values = threshold.values && threshold.values.length ? threshold.values : [],
         max = threshold.max || 100;
-    return notEmpty(config.color_threshold) ? function (value) {
+    return notEmpty(threshold) && notEmpty(colors) ? function (value) {
         var i, v, color = colors[colors.length - 1];
         for (i = 0; i < values.length; i++) {
             v = asValue ? value : (value * 100 / max);


### PR DESCRIPTION

Possible fix of #2324. Seems to be `arc.js:347` is the only line that does not check `levelColor` for emptiness before calling it. Moreover, we can remove `config.color_pattern.length > 0` check and create non-null `levelColor` function if `config.color_pattern` is not empty - otherwise undefined color that would be returned from `levelColor` does not make much sense.