### PR TITLE
Fixed chart height determination issue number 2467

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -919,8 +919,6 @@ ChartInternal.prototype.updateSvgSize = function() {
     $$.svg.select('#' + $$.clipIdForSubchart).select('rect')
         .attr('width', $$.width)
         .attr('height', brush.size() ? brush.attr('height') : 0);
-    // MEMO: parent div's height will be bigger than svg when <!DOCTYPE html>
-    $$.selectChart.style('max-height', $$.currentHeight + "px");
 };
 
 ChartInternal.prototype.updateDimension = function(withoutAxis) {

--- a/src/size.js
+++ b/src/size.js
@@ -73,8 +73,7 @@ ChartInternal.prototype.getParentWidth = function () {
     return this.getParentRectValue('width');
 };
 ChartInternal.prototype.getParentHeight = function () {
-    var h = this.selectChart.style('height');
-    return h.indexOf('px') > 0 ? +h.replace('px', '') : 0;
+    return this.getParentRectValue('height');
 };
 
 


### PR DESCRIPTION
I changed the getParentHeight function to get the actual height of the parent element. I also removed the 'max-height' CSS style that was applied so that the chart could be resized properly when the browser window is resized. 

All changes passed the current tests and do not require any new tests. 