### PR TITLE
Added index to tooltip’s title format callback

### DIFF
--- a/docs/reference.html.haml
+++ b/docs/reference.html.haml
@@ -2742,7 +2742,7 @@
           = partial :reference_item_link, locals: { id: 'tooltip.format.title' }
         %p Set format for the title of tooltip.
         %br
-        %p Specified function receives <span class="code">x</span> of the data point to show.
+        %p Specified function receives <span class="code">x</span> and <span class="code">index</span> of the data point to show.
         %h5 Default:
         <code>undefined</code>
         %h5 Format:
@@ -2751,7 +2751,7 @@
             %code.html.javascript
               tooltip: {
               &nbsp;&nbsp;format: {
-              &nbsp;&nbsp;&nbsp;&nbsp;title: function (x) { return 'Data ' + x; }
+              &nbsp;&nbsp;&nbsp;&nbsp;title: function (x, index) { return 'Data ' + x; }
               &nbsp;&nbsp;}
               }
         %h5 Example:

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -131,7 +131,7 @@ ChartInternal.prototype.getTooltipContent = function (d, defaultTitleFormat, def
         }
 
         if (!text) {
-            title = sanitise(titleFormat ? titleFormat(d[i].x) : d[i].x);
+            title = sanitise(titleFormat ? titleFormat(d[i].x, d[i].index) : d[i].x);
             text = "<table class='" + $$.CLASS.tooltip + "'>" + (title || title === 0 ? "<tr><th colspan='2'>" + title + "</th></tr>" : "");
         }
 


### PR DESCRIPTION
This PR adds the index value to the tooltip’s configurable title format callback.

Like with the configurable value format callback, the index could be useful to know which part of the dataset the title belongs to (and not only deduced from x, which is a displayable name not an index).