### PR TITLE
Fix generateGetBarPoints when axis rotated and y inverted

### DIFF
--- a/spec/shape.bar-spec.js
+++ b/spec/shape.bar-spec.js
@@ -44,6 +44,60 @@ describe('c3 chart shape bar', function () {
             });
 
         });
+
+        describe('with rotated axis', function () {
+
+            beforeAll(function () {
+                args.axis = {rotated: true};
+            });
+
+            it('bars should have expected Path Box', function () {
+                var expected = {
+                    x: 0,
+                    y: 193,
+                    width: 536,
+                    height: 40
+                };
+    
+                var shapes = chart.internal.main
+                    .selectAll('.' + chart.internal.CLASS.shapes)
+                    .selectAll('.' + chart.internal.CLASS.shape);
+                shapes.each(function () {
+                    var pathBox = chart.internal.getPathBox(this);
+                    expect(pathBox.x).toBeCloseTo(expected.x, -1);
+                    expect(pathBox.y).toBeCloseTo(expected.y, -1);
+                    expect(pathBox.width).toBeCloseTo(expected.width, -1);
+                    expect(pathBox.height).toBeCloseTo(expected.height, -1);
+                });
+            });
+
+            describe('and inverted y axis', function () {
+
+                beforeAll(function () {
+                    args.axis.y = {inverted: true};
+                });
+
+                it('bars should have expected Path Box', function () {
+                    var expected = {
+                        x: 590,
+                        y: 193,
+                        width: 536,
+                        height: 40
+                    };
+        
+                    var shapes = chart.internal.main
+                        .selectAll('.' + chart.internal.CLASS.shapes)
+                        .selectAll('.' + chart.internal.CLASS.shape);
+                    shapes.each(function () {
+                        var pathBox = chart.internal.getPathBox(this);
+                        expect(pathBox.x).toBeCloseTo(expected.x, -1);
+                        expect(pathBox.y).toBeCloseTo(expected.y, -1);
+                        expect(pathBox.width).toBeCloseTo(expected.width, -1);
+                        expect(pathBox.height).toBeCloseTo(expected.height, -1);
+                    });
+                });
+            });
+        });
     });
 
     describe('with groups', function () {

--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -103,10 +103,6 @@ ChartInternal.prototype.generateGetBarPoints = function (barIndices, isSub) {
         var y0 = yScale.call($$, d.id)(0),
             offset = barOffset(d, i) || y0, // offset is for stacked bar chart
             posX = barX(d), posY = barY(d);
-        // fix posY not to overflow opposite quadrant
-        if ($$.config.axis_rotated) {
-            if ((0 < d.value && posY < y0) || (d.value < 0 && y0 < posY)) { posY = y0; }
-        }
         // 4 points that make a bar
         return [
             [posX + barSpaceOffset, offset],


### PR DESCRIPTION
When axis rotated and y inverted, x point for first and second Line to command is incorrect.

fix #1820 

<!--

Thank you for contributing!

Please make sure to:
 
- provide tests with your code changes to ensure they are working as expected.
- not commit any of the distribution file (`c3.js`, `c3.css`, `c3.min.js`, `c3.min.css`).

-->
