### PR TITLE
Added option to only use x postion for tooltips

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -305,6 +305,9 @@
               <a href="./samples/tooltip_grouped.html">
                 Show tooltip as each data
               </a>
+              <a href="./samples/tooltip_horizontal.html">
+                Show tooltip based on horizontal mouse position
+              </a>
             </div>
           </div>
         </div>

--- a/htdocs/samples/tooltip_horizontal.html
+++ b/htdocs/samples/tooltip_horizontal.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="../css/c3.css">
+  </head>
+  <body>
+    <div id="chart"></div>
+
+    <script src="https://d3js.org/d3.v5.min.js" charset="utf-8"></script>
+    <script src="../js/c3.js"></script>
+    <script>
+      var chart = c3.generate({
+        bindto: '#chart',
+        data: {
+          columns: [
+            ['data1', 30, 200, 100, 80, 400, 500, 300, 80, 120, 30, 200, 100, 80, 400, 500, 300, 80],
+          ],
+        },
+        point: {
+          sensitivity: 300
+        },
+        tooltip: {
+          horizontal: true
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/config.js
+++ b/src/config.js
@@ -219,6 +219,7 @@ ChartInternal.prototype.getDefaultConfig = function () {
         tooltip_format_title: undefined,
         tooltip_format_name: undefined,
         tooltip_format_value: undefined,
+        tooltip_horizontal: undefined,
         tooltip_position: undefined,
         tooltip_contents: function (d, defaultTitleFormat, defaultValueFormat, color) {
             return this.getTooltipContent ? this.getTooltipContent(d, defaultTitleFormat, defaultValueFormat, color) : '';

--- a/src/data.js
+++ b/src/data.js
@@ -356,7 +356,7 @@ ChartInternal.prototype.findClosest = function (values, pos) {
     values.filter(function (v) {
         return v && !$$.isBarType(v.id);
     }).forEach(function (v) {
-        var d = $$.dist(v, pos);
+        var d = $$.config.tooltip_horizontal ? $$.horizontalDistance(v, pos) : $$.dist(v, pos);
         if (d < minDist) {
             minDist = d;
             closest = v;
@@ -373,6 +373,14 @@ ChartInternal.prototype.dist = function (data, pos) {
         y = $$.circleY(data, data.index),
         x = $$.x(data.x);
     return Math.sqrt(Math.pow(x - pos[xIndex], 2) + Math.pow(y - pos[yIndex], 2));
+};
+ChartInternal.prototype.horizontalDistance = function(data, pos) {
+    var $$ = this,
+        config = $$.config,
+        xIndex = config.axis_rotated ? 1 : 0,
+        x = $$.x(data.x);
+
+    return Math.abs(x - pos[xIndex]);
 };
 ChartInternal.prototype.convertValuesToStep = function (values) {
     var converted = [].concat(values),


### PR DESCRIPTION
I want to fix #2391, this is a variation of pull request #2476. Short summary: i implemented an option `{ tooltip: { horizontal: true } }` to enable the `horizontalDistance` function from #2476, however my implementation still utilizes `point_sensitivity` as minimum distance.

As mentioned [here](https://github.com/c3js/c3/pull/2476#issuecomment-430184110), horizontal distance does not make sense in all cases e.g. scatter plot. This i way i implemented it as configurable option.

Why not just use high `point_sensitivity`? (like mentioned [here](https://github.com/c3js/c3/pull/2476#issuecomment-429848571)) 
As soon as data points don't have much distance between them the y position has an high impact on the (relative) distance to the mouse pointer. Look at following two screenshots of an chart with high point sensitivity. Note that i moved the mouse only a few pixels and the tooltip jumps 3 data points to the right. I'd like to have behaviour where the tooltip is on the closest x-data-point (implemented by this PR)
![image](https://user-images.githubusercontent.com/12527892/54131574-e692ef00-4412-11e9-82d1-7a231a6527de.png)
![image](https://user-images.githubusercontent.com/12527892/54131585-ed216680-4412-11e9-9260-f5514fb91879.png)

