### PR TITLE
typo default value of multiline

### DIFF
--- a/docs/reference.html.haml
+++ b/docs/reference.html.haml
@@ -1664,7 +1664,7 @@
         %br
         %p If this option is set <code>true</code>, when a tick's text on the x-axis is too long, it splits the text into multiple lines in order to avoid text overlapping.
         %h5 Default:
-        <code>false</code>
+        <code>true</code>
         %h5 Format:
         %div.sourcecode
           %pre


### PR DESCRIPTION
Default value of multiline is `false` on document.

https://c3js.org/reference.html#axis-x-tick-multiline

But, default value of multiline is `true` on code.

https://github.com/c3js/c3/blob/master/src/config.js#L57

<!--

Thank you for contributing!

Please make sure to:
 
- provide tests with your code changes to ensure they are working as expected.
- not commit any of the distribution file (`c3.js`, `c3.css`, `c3.min.js`, `c3.min.css`).

-->
