### PR TITLE
Make sure innerRadius is not NaN value

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -492,7 +492,8 @@ ChartInternal.prototype.redrawArc = function (duration, durationForExit, withTra
         backgroundArc
             .exit()
             .remove();
-
+        
+        $$.innerRadius = $$.innerRadius || 0;
         $$.arcs.select('.' + CLASS.chartArcsGaugeUnit)
             .attr("dy", ".75em")
             .text(config.gauge_label_show ? config.gauge_units : '');


### PR DESCRIPTION
Error: attribute dx: Expected length, "NaNpx".
Replication:
Happens every time lost focus from/to browser tab when gauge chart is dynamically generated.

Investigation:
w = config.gauge_width is has assigned value 10
$$.innerRadiusRatio is -Infinity
$$.innerRadius is NaN

<!--

Thank you for contributing!

Please make sure to:
 
- provide tests with your code changes to ensure they are working as expected.
- not commit any of the distribution file (`c3.js`, `c3.css`, `c3.min.js`, `c3.min.css`).

-->
