### PR TITLE
fixed isWithinBar() crash when there were less than 2 items in pathSe…

### DIFF
--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -117,6 +117,9 @@ ChartInternal.prototype.generateGetBarPoints = function (barIndices, isSub) {
     };
 };
 ChartInternal.prototype.isWithinBar = function (mouse, that) {
+    if (that.pathSegList.numberOfItems < 2) {
+        return false;
+    }
     var box = that.getBoundingClientRect(),
         seg0 = that.pathSegList.getItem(0), seg1 = that.pathSegList.getItem(1),
         x = Math.min(seg0.x, seg1.x), y = Math.min(seg0.y, seg1.y),


### PR DESCRIPTION
Rebased version of #1550

I'm using c3js within a webapp based on Ember and it can happen that charts are drawn & 
destroyed even before they finish loading.

When navigating I can often have the following error happening:

![Capture d’écran 2019-07-26 à 11 16 47](https://user-images.githubusercontent.com/230462/61942211-3c6acc80-af99-11e9-9e28-1198881a7649.png)
