### PR TITLE
Correct positioning of outer xAxis label

### DIFF
--- a/htdocs/samples/axes_x_tick_rotate.html
+++ b/htdocs/samples/axes_x_tick_rotate.html
@@ -24,13 +24,13 @@
             },
             label: {
               text: 'Hogehoge',
-              position: 'outer-middle'
+              position: 'outer-center'
             },
           },
           y: {
             label: {
               text: 'Y Label',
-              position: 'outer-center'
+              position: 'outer-middle'
             }
           }
         },

--- a/htdocs/samples/axes_x_tick_rotate.html
+++ b/htdocs/samples/axes_x_tick_rotate.html
@@ -26,7 +26,6 @@
               text: 'Hogehoge',
               position: 'outer-middle'
             },
-            height: 90,
           },
           y: {
             label: {

--- a/spec/axis-spec.js
+++ b/spec/axis-spec.js
@@ -227,8 +227,6 @@ describe('c3 chart axis', function() {
 
     });
 
-
-
     describe('axis y timeseries', function() {
         beforeAll(function() {
             args = {
@@ -1010,4 +1008,81 @@ describe('c3 chart axis', function() {
         });
     });
 
+    describe('axis.x.label', function() {
+        beforeAll(function() {
+            args = {
+                data: {
+                    columns: [
+                        ['somewhat long 1', 30, 200, 100, 400, 150, 250],
+                        ['somewhat long 2', 50, 20, 10, 40, 15, 25]
+                    ]
+                },
+                axis: {
+                    x: {
+                        show: true,
+                        label: {
+                            text: 'Label of X axis'
+                        }
+                    }
+                }
+            };
+        });
+
+        it('renders label text properly', () => {
+            expect(d3.select('.c3-axis-x-label').text()).toEqual('Label of X axis');
+        });
+
+        describe('outer label position', function() {
+            beforeAll(function() {
+                args.axis.x.label.position = 'outer-center';
+            });
+
+            it('renders position properly', () => {
+                const label = d3.select('.c3-axis-x-label');
+
+                expect(label.attr('dy')).toEqual('30');
+            });
+
+            describe('with rotated tick', function() {
+                beforeAll(function() {
+                    args.axis.x.tick = {
+                        rotate: 90
+                    };
+                });
+
+                it('renders position properly', () => {
+                    const label = d3.select('.c3-axis-x-label');
+
+                    expect(label.attr('dy')).toBeGreaterThan('30');
+                });
+            });
+        });
+
+        describe('inner label position', function() {
+            beforeAll(function() {
+                args.axis.x.label.position = 'inner-center';
+            });
+
+            it('renders position properly', () => {
+                const label = d3.select('.c3-axis-x-label');
+
+                expect(label.attr('dy')).toEqual('-0.5em');
+            });
+
+            describe('with rotated tick', function() {
+                beforeAll(function() {
+                    args.axis.x.tick = {
+                        rotate: 90
+                    };
+                });
+
+                it('renders position properly', () => {
+                    const label = d3.select('.c3-axis-x-label');
+
+                    expect(label.attr('dy')).toEqual('-0.5em');
+                });
+            });
+        });
+
+    });
 });

--- a/src/axis.js
+++ b/src/axis.js
@@ -264,7 +264,7 @@ Axis.prototype.dyForXAxisLabel = function dyForXAxisLabel() {
     if (config.axis_rotated) {
         return position.isInner ? "1.2em" : -25 - ($$.config.axis_x_inner ? 0 : this.getMaxTickWidth('x'));
     } else {
-        return position.isInner ? "-0.5em" : config.axis_x_height ? config.axis_x_height - 10 : "3em";
+        return position.isInner ? "-0.5em" : $$.getHorizontalAxisHeight('x') - 10;
     }
 };
 Axis.prototype.dyForYAxisLabel = function dyForYAxisLabel() {


### PR DESCRIPTION
Avoid overlapping between xAxis ticks & label when the former uses the rotate option.

