### PR TITLE
add bundle resources to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ components
 # IDE related
 .idea
 .iml
+
+# bundle
+.bundle/config
+vendor/bundle


### PR DESCRIPTION
When you contribue to the documentation, using RVM & bundle creates new files locally.

They are dev specific to let's add them to .gitignore