### PR TITLE
Fix: tween callbacks run after chart is destroyed.

### DIFF
--- a/spec/arc-spec.js
+++ b/spec/arc-spec.js
@@ -39,7 +39,7 @@ describe('c3 chart arc', function () {
           expect(chart.internal.config).toBeNull();
           done();
         }, 501);
-      })
+      });
     });
 
     describe('show pie chart', function () {

--- a/spec/arc-spec.js
+++ b/spec/arc-spec.js
@@ -7,6 +7,41 @@ describe('c3 chart arc', function () {
         chart = window.initChart(chart, args, done);
     });
 
+    describe('unloads correctly', function() {
+
+      beforeAll(function () {
+        args = {
+            data: {
+                columns: [
+                    ['data1', 30],
+                    ['data2', 150],
+                    ['data3', 120]
+                ],
+                type: 'pie'
+            },
+            transition: {
+              duration: 500
+            }
+        };
+      });
+
+      it('unloads without error', function(done) {
+        chart.load({
+          columns: [['data2', 30, 20, 50, 40, 60, 50]]
+        });
+
+      
+        setTimeout(function () {
+            chart.destroy();
+        }, 200);
+
+        setTimeout(function() {
+          expect(chart.internal.config).toBeNull();
+          done();
+        }, 501);
+      })
+    });
+
     describe('show pie chart', function () {
 
         beforeAll(function () {

--- a/src/arc.js
+++ b/src/arc.js
@@ -452,6 +452,10 @@ ChartInternal.prototype.redrawArc = function (duration, durationForExit, withTra
             interpolate = d3.interpolate(this._current, updated);
             this._current = interpolate(0);
             return function (t) {
+                // prevents crashing the charts once in transition and chart.destroy() has been called
+                if ($$.config === null) {
+                  return "M 0 0";
+                }
                 var interpolated = interpolate(t);
                 interpolated.data = d.data; // data.id will be updated by interporator
                 return $$.getArc(interpolated, true);


### PR DESCRIPTION
#2213

- This causes some issues when unloading arc type charts

previous PR was abandoned, but we still see this error quite a bit, would like to see this cleaned up.

<!--

Thank you for contributing!

Please make sure to:
 
- provide tests with your code changes to ensure they are working as expected.
- not commit any of the distribution file (`c3.js`, `c3.css`, `c3.min.js`, `c3.min.css`).

-->
