### PR TITLE
Restore tooltip behavior when grouped

### DIFF
--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -46,6 +46,9 @@ describe('c3 chart interaction', function () {
             });
 
             describe('mouseover', function () {
+                let mouseoutCounter = 0;
+                let mouseoverCounter = 0;
+
                 beforeAll(function () {
                     args = {
                         data: {
@@ -56,10 +59,10 @@ describe('c3 chart interaction', function () {
                             ],
                             type: 'bar',
                             onmouseout: function() {
-                                window.mouseoutCounter += 1;
+                                mouseoutCounter += 1;
                             },
                             onmouseover: function() {
-                                window.mouseoverCounter += 1;
+                                mouseoverCounter += 1;
                             }
                         },
                         axis: {
@@ -69,23 +72,23 @@ describe('c3 chart interaction', function () {
                 });
 
                 beforeEach(function() {
-                    window.mouseoverCounter = 0;
-                    window.mouseoutCounter = 0;
+                    mouseoverCounter = 0;
+                    mouseoutCounter = 0;
                 });
 
                 it('should be undefined when not within bar', function () {
                     moveMouseOut();
 
-                    expect(window.mouseoutCounter).toEqual(0);
-                    expect(window.mouseoverCounter).toEqual(0);
+                    expect(mouseoutCounter).toEqual(0);
+                    expect(mouseoverCounter).toEqual(0);
                     expect(chart.internal.mouseover).toBeUndefined();
                 });
 
                 it('should be data value when within bar', function () {
                     moveMouse(31, 280);
 
-                    expect(window.mouseoutCounter).toEqual(0);
-                    expect(window.mouseoverCounter).toEqual(1);
+                    expect(mouseoutCounter).toEqual(0);
+                    expect(mouseoverCounter).toEqual(1);
                     expect(chart.internal.mouseover).toEqual({
                         x: 0,
                         value: 30,
@@ -99,8 +102,8 @@ describe('c3 chart interaction', function () {
                     moveMouse(31, 280);
                     moveMouseOut();
 
-                    expect(window.mouseoutCounter).toEqual(1);
-                    expect(window.mouseoverCounter).toEqual(1);
+                    expect(mouseoutCounter).toEqual(1);
+                    expect(mouseoverCounter).toEqual(1);
                     expect(chart.internal.mouseover).toBeUndefined();
                 });
 
@@ -109,8 +112,8 @@ describe('c3 chart interaction', function () {
                     moveMouseOut();
                     moveMouse(31, 280);
 
-                    expect(window.mouseoutCounter).toEqual(1);
-                    expect(window.mouseoverCounter).toEqual(2);
+                    expect(mouseoutCounter).toEqual(1);
+                    expect(mouseoverCounter).toEqual(2);
                     expect(chart.internal.mouseover).toEqual({
                         x: 0,
                         value: 30,
@@ -377,6 +380,8 @@ describe('c3 chart interaction', function () {
 
     describe('line chart', function() {
         describe('tooltip_grouped=false', function() {
+            let clickedData = [];
+
             beforeAll(() => {
                 args = {
                     data: {
@@ -390,7 +395,7 @@ describe('c3 chart interaction', function () {
                             [ 'data1', 'data2' ]
                         ],
                         onclick: function(d) {
-                            window.clickedData.push(d);
+                            clickedData.push(d);
                         }
                     },
                     tooltip: {
@@ -418,7 +423,7 @@ describe('c3 chart interaction', function () {
             });
 
             beforeEach(function() {
-                window.clickedData = [];
+                clickedData = [];
             });
 
             it('shows tooltip with only hovered data', () => {
@@ -478,7 +483,7 @@ describe('c3 chart interaction', function () {
             it('clicks only on hovered point', () => {
                 clickMouse(144, 201);
 
-                expect(window.clickedData).toEqual([{
+                expect(clickedData).toEqual([{
                     x: 1,
                     index: 1,
                     value: 200,
@@ -542,7 +547,7 @@ describe('c3 chart interaction', function () {
                     clickMouse(340, 203);
                     clickMouse(537, 386);
 
-                    expect(window.clickedData).toEqual([
+                    expect(clickedData).toEqual([
                         {x: 1, value: -200, id: 'data3', index: 1, name: 'data3'},
                         {x: 3, value: 200, id: 'data2', index: 3, name: 'data2'},
                         {x: 5, value: -250, id: 'data1', index: 5, name: 'data1'}
@@ -580,6 +585,8 @@ describe('c3 chart interaction', function () {
         });
 
         describe('tooltip_grouped=true', function() {
+            let clickedData = [];
+
             beforeAll(() => {
                 args = {
                     data: {
@@ -593,7 +600,7 @@ describe('c3 chart interaction', function () {
                             [ 'data1', 'data2' ]
                         ],
                         onclick: function(d) {
-                            window.clickedData.push(d);
+                            clickedData.push(d);
                         }
                     },
                     tooltip: {
@@ -621,7 +628,7 @@ describe('c3 chart interaction', function () {
             });
 
             beforeEach(function() {
-                window.clickedData = [];
+                clickedData = [];
             });
 
             describe('with tooltip_horizontal=true', () => {
@@ -639,7 +646,7 @@ describe('c3 chart interaction', function () {
                     clickMouse(340, 203);
                     clickMouse(537, 386);
 
-                    expect(window.clickedData).toEqual([
+                    expect(clickedData).toEqual([
                         {x: 1, value: -200, id: 'data3', index: 1, name: 'data3'},
                         {x: 3, value: 200, id: 'data2', index: 3, name: 'data2'},
                         {x: 5, value: -250, id: 'data1', index: 5, name: 'data1'}

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -537,9 +537,9 @@ describe('c3 chart interaction', function () {
                         x: 'x',
                         columns: [
                             [ 'x', '2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05', '2018-01-06'],
-                            [ 'data1', 30, 200, 200, 400, 150, -250 ],
-                            [ 'data2', 130, -100, 100, 200, 150, 50 ],
-                            [ 'data3', 230, -200, 200, 0, 250, 250 ]
+                            [ 'data1', 30, 200, 200, 400, 150, 250 ],
+                            [ 'data2', 130, 100, 100, 200, 150, 50 ],
+                            [ 'data3', 230, 200, 200, 0, 250, 250 ]
                         ],
                         type: 'area',
                         groups: [
@@ -552,23 +552,12 @@ describe('c3 chart interaction', function () {
                     axis: {
                         x: {
                             type: 'timeseries'
-                        },
-                        rotated: true
+                        }
                     },
                     interaction: {
                         enabled: true
                     }
                 };
-            });
-
-            it('generate a single rect', () => {
-                const eventRectList = d3.selectAll('.c3-event-rect');
-
-                expect(eventRectList.size()).toBe(1);
-                expect(eventRectList.attr('x')).toEqual('0');
-                expect(eventRectList.attr('y')).toEqual('0');
-                expect(eventRectList.attr('height')).toEqual('' + chart.internal.height);
-                expect(eventRectList.attr('width')).toEqual('' + chart.internal.width);
             });
 
             it('shows tooltip with visible data of currently hovered category', () => {
@@ -578,13 +567,14 @@ describe('c3 chart interaction', function () {
 
                 const tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
 
-                expect(tooltipData.length).toBe(3); // header + data[123]
+                expect(tooltipData.length).toBe(4); // header + data[123]
 
-                expect(tooltipData[1].querySelector('.name').textContent).toBe('data3');
-                expect(tooltipData[2].querySelector('.name').textContent).toBe('data2');
+                expect(tooltipData[1].querySelector('.name').textContent).toBe('data1');
+                expect(tooltipData[2].querySelector('.name').textContent).toBe('data3');
+                expect(tooltipData[3].querySelector('.name').textContent).toBe('data2');
             });
 
-            it('shows cursor:pointer only if hovering bar', () => {
+            it('shows cursor:pointer only if hovering area', () => {
                 const eventRect = d3.select('.c3-event-rect');
 
                 moveMouse(1, 1);
@@ -599,32 +589,6 @@ describe('c3 chart interaction', function () {
 
                 expect(eventRect.style('cursor')).toEqual('auto');
             });
-
-            it('expands all bars of currently hovered category', () => {
-                moveMouse(20, 20);
-
-                const barList = d3.selectAll('.c3-bar');
-
-                expect(barList.size()).toBeGreaterThan(0);
-
-                barList.each(function() {
-                    if (this.classList.contains('c3-bar-0') && !this.parentElement.classList.contains('c3-bars-data1')) {
-                        expect(this.classList.contains('_expanded_')).toBeTruthy();
-                    } else {
-                        expect(this.classList.contains('_expanded_')).toBeFalsy();
-                    }
-                });
-
-                moveMouse(20, chart.internal.x(2.4));
-
-                barList.each(function() {
-                    if (this.classList.contains('c3-bar-2') && !this.parentElement.classList.contains('c3-bars-data1')) {
-                        expect(this.classList.contains('_expanded_')).toBeTruthy();
-                    } else {
-                        expect(this.classList.contains('_expanded_')).toBeFalsy();
-                    }
-                });
-            });
         });
 
         describe('tooltip_grouped=false', function() {
@@ -634,9 +598,9 @@ describe('c3 chart interaction', function () {
                         x: 'x',
                         columns: [
                             [ 'x', '2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05', '2018-01-06'],
-                            [ 'data1', 30, 200, 200, 400, 150, -250 ],
-                            [ 'data2', 130, -100, 100, 200, 150, 50 ],
-                            [ 'data3', 230, -200, 200, 0, 250, 250 ]
+                            [ 'data1', 30, 200, 200, 400, 150, 250 ],
+                            [ 'data2', 130, 100, 100, 200, 150, 50 ],
+                            [ 'data3', 230, 200, 200, 0, 250, 250 ]
                         ],
                         type: 'area',
                         groups: [
@@ -658,54 +622,21 @@ describe('c3 chart interaction', function () {
                 };
             });
 
-            it('generate a single rect', () => {
-                const eventRectList = d3.selectAll('.c3-event-rect');
-
-                expect(eventRectList.size()).toBe(1);
-                expect(eventRectList.attr('x')).toEqual('0');
-                expect(eventRectList.attr('y')).toEqual('0');
-                expect(eventRectList.attr('height')).toEqual('' + chart.internal.height);
-                expect(eventRectList.attr('width')).toEqual('' + chart.internal.width);
-            });
-
             it('shows tooltip with only hovered data', () => {
                 moveMouse(1, 1);
 
                 expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('none');
 
-                moveMouse(35, 268);
+                moveMouse(5, 174);
 
                 expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
 
                 const tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
 
-                expect(tooltipData.length).toBe(2); // header + data2
+                expect(tooltipData.length).toBe(2); // header + data1
 
-                expect(tooltipData[1].querySelector('.name').textContent).toBe('data2');
-                expect(tooltipData[1].querySelector('.value').textContent).toBe('130');
-            });
-
-            it('expands only hovered bar', () => {
-                moveMouse(20, 20);
-
-                const barList = d3.selectAll('.c3-bar');
-
-                expect(barList.size()).toBeGreaterThan(0);
-
-                // nothing expanded
-                barList.each(function() {
-                    expect(this.classList.contains('_expanded_')).toBeFalsy();
-                });
-
-                moveMouse(38, 258);
-
-                barList.each(function() {
-                    if (this.classList.contains('c3-bar-0') && this.parentElement.classList.contains('c3-bars-data2')) {
-                        expect(this.classList.contains('_expanded_')).toBeTruthy();
-                    } else {
-                        expect(this.classList.contains('_expanded_')).toBeFalsy();
-                    }
-                });
+                expect(tooltipData[1].querySelector('.name').textContent).toBe('data1');
+                expect(tooltipData[1].querySelector('.value').textContent).toBe('30');
             });
         });
     });

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -685,6 +685,63 @@ describe('c3 chart interaction', function () {
         });
     });
 
+    describe('scatter chart', function() {
+       describe('tooltip_grouped=true', function() {
+           beforeAll(() => {
+                args = {
+                    data: {
+                        columns: [
+                            ['data1', 30, null, 100, 400, -150, 250],
+                            ['data2', 50, 20, 10, 40, 15, 25],
+                            ['data3', -150, 120, 110, 140, 115, 125]
+                        ],
+                        type: 'scatter'
+                    },
+                    tooltip: {
+                        grouped: true
+                    },
+                    interaction: {
+                        enabled: true
+                    }
+                };
+           });
+
+           it('shows tooltip with visible data of currently hovered category', () => {
+               moveMouse(20, 20);
+
+               let tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+               expect(tooltipData.length).toBe(4); // header + data[123]
+
+               expect(tooltipData[1].querySelector('.name').textContent).toBe('data2');
+               expect(tooltipData[1].querySelector('.value').textContent).toBe('50');
+               expect(tooltipData[2].querySelector('.name').textContent).toBe('data1');
+               expect(tooltipData[2].querySelector('.value').textContent).toBe('30');
+               expect(tooltipData[3].querySelector('.name').textContent).toBe('data3');
+               expect(tooltipData[3].querySelector('.value').textContent).toBe('-150');
+
+               moveMouse(350, 354);
+
+               tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+               expect(tooltipData.length).toBe(4); // header + data[123]
+
+               expect(tooltipData[1].querySelector('.name').textContent).toBe('data1');
+               expect(tooltipData[1].querySelector('.value').textContent).toBe('400');
+               expect(tooltipData[2].querySelector('.name').textContent).toBe('data3');
+               expect(tooltipData[2].querySelector('.value').textContent).toBe('140');
+               expect(tooltipData[3].querySelector('.name').textContent).toBe('data2');
+               expect(tooltipData[3].querySelector('.value').textContent).toBe('40');
+           });
+
+           it('shows x grid', () => {
+               moveMouse(20, 20);
+
+               expect(d3.select('.c3-xgrid-focus').style('visibility')).toBe('visible');
+           });
+       });
+    });
+
     describe('area chart (timeseries)', function() {
         describe('tooltip_grouped=true', function() {
             beforeAll(() => {

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -37,9 +37,12 @@ describe('c3 chart interaction', function () {
             });
 
             describe('mouseover', function () {
+                const moveMouse = (event, x = 0, y = 0) =>
+                    setMouseEvent(chart, event, x, y, d3.select('.c3-event-rect').node());
 
                 beforeAll(function () {
                     window.mouseoverCounter = 0;
+                    window.mouseoutCounter = 0;
                     args = {
                         data: {
                             columns: [
@@ -48,7 +51,10 @@ describe('c3 chart interaction', function () {
                                 ['data3', -150, 120, 110, 140, 115, 125]
                             ],
                             type: 'bar',
-                            mouseover: function(){
+                            onmouseout: function() {
+                                window.mouseoutCounter += 1;
+                            },
+                            onmouseover: function() {
                                 window.mouseoverCounter += 1;
                             }
                         },
@@ -58,32 +64,51 @@ describe('c3 chart interaction', function () {
                     };
                 });
 
-                it('should be false when not within bar', function () {
-                    setMouseEvent(chart, 'mousemove', 0, 0);
-                    expect(chart.internal.mouseover).toBeFalsy();
+                it('should be undefined when not within bar', function () {
+                    moveMouse('mouseout');
+
+                    expect(window.mouseoutCounter).toEqual(0);
+                    expect(window.mouseoverCounter).toEqual(0);
+                    expect(chart.internal.mouseover).toBeUndefined();
                 });
 
                 it('should be data value when within bar', function () {
-                    setMouseEvent(chart, 'mousemove', 31, 280);
-                    expect(chart.internal.mouseover).toBe({
+                    moveMouse('mousemove', 31, 280);
+
+                    expect(window.mouseoutCounter).toEqual(0);
+                    expect(window.mouseoverCounter).toEqual(1);
+                    expect(chart.internal.mouseover).toEqual({
                         x: 0,
                         value: 30,
+                        index: 0,
                         id: 'data1',
                         name: 'data1'
                     });
                 });
 
-                it('should be false after leaving chart', function () {
-                    setMouseEvent(chart, 'mousemove', 31, 280);
-                    setMouseEvent(chart, 'mouseout', 0, 0);
-                    expect(chart.internal.mouseover).toBeFalsy();
+                it('should be undefined after leaving chart', function () {
+                    moveMouse('mousemove', 31, 280);
+                    moveMouse('mouseout');
+
+                    expect(window.mouseoutCounter).toEqual(1);
+                    expect(window.mouseoverCounter).toEqual(1);
+                    expect(chart.internal.mouseover).toBeUndefined();
                 });
 
                 it('should retrigger mouseover event when returning to same value', function () {
-                    setMouseEvent(chart, 'mousemove', 31, 280);
-                    setMouseEvent(chart, 'mouseout', 0, 0);
-                    setMouseEvent(chart, 'mousemove', 31, 280);
-                    expect(window.mouseoverCounter).toBe(2);
+                    moveMouse('mousemove', 31, 280);
+                    moveMouse('mouseout');
+                    moveMouse('mousemove', 31, 280);
+
+                    expect(window.mouseoutCounter).toEqual(1);
+                    expect(window.mouseoverCounter).toEqual(2);
+                    expect(chart.internal.mouseover).toEqual({
+                        x: 0,
+                        value: 30,
+                        index: 0,
+                        id: 'data1',
+                        name: 'data1'
+                    });
                 });
             });
 

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -1,3 +1,5 @@
+var setMouseEvent = window.setMouseEvent;
+
 describe('c3 chart interaction', function () {
     'use strict';
 
@@ -31,6 +33,57 @@ describe('c3 chart interaction', function () {
                     var box = d3.select(this).node().getBoundingClientRect();
                     expect(box.left).toBeCloseTo(40.5, -2);
                     expect(box.width).toBeCloseTo(598, -2);
+                });
+            });
+
+            describe('mouseover', function () {
+
+                beforeAll(function () {
+                    window.mouseoverCounter = 0;
+                    args = {
+                        data: {
+                            columns: [
+                                ['data1', 30, 200, 100, 400, -150, 250],
+                                ['data2', 50, 20, 10, 40, 15, 25],
+                                ['data3', -150, 120, 110, 140, 115, 125]
+                            ],
+                            type: 'bar',
+                            mouseover: function(){
+                                window.mouseoverCounter += 1;
+                            }
+                        },
+                        axis: {
+                            rotated: false
+                        }
+                    };
+                });
+
+                it('should be false when not within bar', function () {
+                    setMouseEvent(chart, 'mousemove', 0, 0);
+                    expect(chart.internal.mouseover).toBeFalsy();
+                });
+
+                it('should be data value when within bar', function () {
+                    setMouseEvent(chart, 'mousemove', 31, 280);
+                    expect(chart.internal.mouseover).toBe({
+                        x: 0,
+                        value: 30,
+                        id: 'data1',
+                        name: 'data1'
+                    });
+                });
+
+                it('should be false after leaving chart', function () {
+                    setMouseEvent(chart, 'mousemove', 31, 280);
+                    setMouseEvent(chart, 'mouseout', 0, 0);
+                    expect(chart.internal.mouseover).toBeFalsy();
+                });
+
+                it('should retrigger mouseover event when returning to same value', function () {
+                    setMouseEvent(chart, 'mousemove', 31, 280);
+                    setMouseEvent(chart, 'mouseout', 0, 0);
+                    setMouseEvent(chart, 'mousemove', 31, 280);
+                    expect(window.mouseoverCounter).toBe(2);
                 });
             });
 

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -529,6 +529,187 @@ describe('c3 chart interaction', function () {
         });
     });
 
+    describe('area chart (timeseries)', function() {
+        describe('tooltip_grouped=true', function() {
+            beforeAll(() => {
+                args = {
+                    data: {
+                        x: 'x',
+                        columns: [
+                            [ 'x', '2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05', '2018-01-06'],
+                            [ 'data1', 30, 200, 200, 400, 150, -250 ],
+                            [ 'data2', 130, -100, 100, 200, 150, 50 ],
+                            [ 'data3', 230, -200, 200, 0, 250, 250 ]
+                        ],
+                        type: 'area',
+                        groups: [
+                            [ 'data1', 'data2', 'data3' ]
+                        ]
+                    },
+                    tooltip: {
+                        grouped: true
+                    },
+                    axis: {
+                        x: {
+                            type: 'timeseries'
+                        },
+                        rotated: true
+                    },
+                    interaction: {
+                        enabled: true
+                    }
+                };
+            });
+
+            it('generate a single rect', () => {
+                const eventRectList = d3.selectAll('.c3-event-rect');
+
+                expect(eventRectList.size()).toBe(1);
+                expect(eventRectList.attr('x')).toEqual('0');
+                expect(eventRectList.attr('y')).toEqual('0');
+                expect(eventRectList.attr('height')).toEqual('' + chart.internal.height);
+                expect(eventRectList.attr('width')).toEqual('' + chart.internal.width);
+            });
+
+            it('shows tooltip with visible data of currently hovered category', () => {
+                moveMouse(20, 20);
+
+                expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
+
+                const tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+                expect(tooltipData.length).toBe(3); // header + data[123]
+
+                expect(tooltipData[1].querySelector('.name').textContent).toBe('data3');
+                expect(tooltipData[2].querySelector('.name').textContent).toBe('data2');
+            });
+
+            it('shows cursor:pointer only if hovering bar', () => {
+                const eventRect = d3.select('.c3-event-rect');
+
+                moveMouse(1, 1);
+
+                expect(eventRect.style('cursor')).toEqual('auto');
+
+                moveMouse(360, 48);
+
+                expect(eventRect.style('cursor')).toEqual('pointer');
+
+                moveMouse(1, 1);
+
+                expect(eventRect.style('cursor')).toEqual('auto');
+            });
+
+            it('expands all bars of currently hovered category', () => {
+                moveMouse(20, 20);
+
+                const barList = d3.selectAll('.c3-bar');
+
+                expect(barList.size()).toBeGreaterThan(0);
+
+                barList.each(function() {
+                    if (this.classList.contains('c3-bar-0') && !this.parentElement.classList.contains('c3-bars-data1')) {
+                        expect(this.classList.contains('_expanded_')).toBeTruthy();
+                    } else {
+                        expect(this.classList.contains('_expanded_')).toBeFalsy();
+                    }
+                });
+
+                moveMouse(20, chart.internal.x(2.4));
+
+                barList.each(function() {
+                    if (this.classList.contains('c3-bar-2') && !this.parentElement.classList.contains('c3-bars-data1')) {
+                        expect(this.classList.contains('_expanded_')).toBeTruthy();
+                    } else {
+                        expect(this.classList.contains('_expanded_')).toBeFalsy();
+                    }
+                });
+            });
+        });
+
+        describe('tooltip_grouped=false', function() {
+            beforeAll(() => {
+                args = {
+                    data: {
+                        x: 'x',
+                        columns: [
+                            [ 'x', '2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05', '2018-01-06'],
+                            [ 'data1', 30, 200, 200, 400, 150, -250 ],
+                            [ 'data2', 130, -100, 100, 200, 150, 50 ],
+                            [ 'data3', 230, -200, 200, 0, 250, 250 ]
+                        ],
+                        type: 'area',
+                        groups: [
+                            [ 'data1', 'data2', 'data3' ]
+                        ]
+                    },
+                    tooltip: {
+                        grouped: false
+                    },
+                    axis: {
+                        x: {
+                            type: 'timeseries'
+                        },
+                        rotated: false
+                    },
+                    interaction: {
+                        enabled: true
+                    }
+                };
+            });
+
+            it('generate a single rect', () => {
+                const eventRectList = d3.selectAll('.c3-event-rect');
+
+                expect(eventRectList.size()).toBe(1);
+                expect(eventRectList.attr('x')).toEqual('0');
+                expect(eventRectList.attr('y')).toEqual('0');
+                expect(eventRectList.attr('height')).toEqual('' + chart.internal.height);
+                expect(eventRectList.attr('width')).toEqual('' + chart.internal.width);
+            });
+
+            it('shows tooltip with only hovered data', () => {
+                moveMouse(1, 1);
+
+                expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('none');
+
+                moveMouse(35, 268);
+
+                expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
+
+                const tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+                expect(tooltipData.length).toBe(2); // header + data2
+
+                expect(tooltipData[1].querySelector('.name').textContent).toBe('data2');
+                expect(tooltipData[1].querySelector('.value').textContent).toBe('130');
+            });
+
+            it('expands only hovered bar', () => {
+                moveMouse(20, 20);
+
+                const barList = d3.selectAll('.c3-bar');
+
+                expect(barList.size()).toBeGreaterThan(0);
+
+                // nothing expanded
+                barList.each(function() {
+                    expect(this.classList.contains('_expanded_')).toBeFalsy();
+                });
+
+                moveMouse(38, 258);
+
+                barList.each(function() {
+                    if (this.classList.contains('c3-bar-0') && this.parentElement.classList.contains('c3-bars-data2')) {
+                        expect(this.classList.contains('_expanded_')).toBeTruthy();
+                    } else {
+                        expect(this.classList.contains('_expanded_')).toBeFalsy();
+                    }
+                });
+            });
+        });
+    });
+
     describe('disabled', function() {
         beforeAll(() => {
             args = {

--- a/spec/interaction-spec.js
+++ b/spec/interaction-spec.js
@@ -526,6 +526,162 @@ describe('c3 chart interaction', function () {
                     expect(d3.select('.c3-circles-data2 .c3-circle-3._selected_').size()).toEqual(1);
                 });
             });
+
+            describe('with tooltip_horizontal=true', () => {
+                beforeAll(() => {
+                    args.tooltip.horizontal = true;
+                });
+
+                it('can clicks on points', () => {
+                    // out of point sensitivity
+                    clickMouse(146, 46);
+                    clickMouse(343, 263);
+
+                    // click 3 data point
+                    clickMouse(147, 370);
+                    clickMouse(340, 203);
+                    clickMouse(537, 386);
+
+                    expect(window.clickedData).toEqual([
+                        {x: 1, value: -200, id: 'data3', index: 1, name: 'data3'},
+                        {x: 3, value: 200, id: 'data2', index: 3, name: 'data2'},
+                        {x: 5, value: -250, id: 'data1', index: 5, name: 'data1'}
+                    ]);
+                });
+
+                it('shows tooltip with only closest data', () => {
+                    moveMouse(1, 1);
+
+                    expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('none');
+
+                    moveMouse(146, 46);
+
+                    expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
+
+                    let tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+                    expect(tooltipData.length).toBe(2); // header + data1
+
+                    expect(tooltipData[1].querySelector('.name').textContent).toBe('data1');
+                    expect(tooltipData[1].querySelector('.value').textContent).toBe('200');
+
+                    moveMouse(343, 263);
+
+                    expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
+
+                    tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+                    expect(tooltipData.length).toBe(2); // header + data3
+
+                    expect(tooltipData[1].querySelector('.name').textContent).toBe('data3');
+                    expect(tooltipData[1].querySelector('.value').textContent).toBe('0');
+                });
+            });
+        });
+
+        describe('tooltip_grouped=true', function() {
+            beforeAll(() => {
+                args = {
+                    data: {
+                        columns: [
+                            [ 'data1', 30, 200, 200, 400, 150, -250 ],
+                            [ 'data2', 130, -100, 100, 200, 150, 50 ],
+                            [ 'data3', 230, -200, 200, 0, 250, 250 ]
+                        ],
+                        type: 'line',
+                        groups: [
+                            [ 'data1', 'data2' ]
+                        ],
+                        onclick: function(d) {
+                            window.clickedData.push(d);
+                        }
+                    },
+                    tooltip: {
+                        grouped: true
+                    },
+                    axis: {
+                        x: {
+                            type: 'category'
+                        }
+                    },
+                    interaction: {
+                        enabled: true
+                    },
+                    point: {
+                        r: 2,
+                        sensitivity: 10,
+                        focus: {
+                            expand: {
+                                enabled: true,
+                                r: 8
+                            }
+                        }
+                    }
+                };
+            });
+
+            beforeEach(function() {
+                window.clickedData = [];
+            });
+
+            describe('with tooltip_horizontal=true', () => {
+                beforeAll(() => {
+                    args.tooltip.horizontal = true;
+                });
+
+                it('can clicks on points', () => {
+                    // out of point sensitivity
+                    clickMouse(146, 46);
+                    clickMouse(343, 263);
+
+                    // click 3 data point
+                    clickMouse(147, 370);
+                    clickMouse(340, 203);
+                    clickMouse(537, 386);
+
+                    expect(window.clickedData).toEqual([
+                        {x: 1, value: -200, id: 'data3', index: 1, name: 'data3'},
+                        {x: 3, value: 200, id: 'data2', index: 3, name: 'data2'},
+                        {x: 5, value: -250, id: 'data1', index: 5, name: 'data1'}
+                    ]);
+                });
+
+                it('shows tooltip with all data', () => {
+                    moveMouse(1, 1);
+
+                    expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
+
+                    let tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+                    expect(tooltipData.length).toBe(4); // header + data[123]
+
+                    expect(tooltipData[1].querySelector('.name').textContent).toBe('data1');
+                    expect(tooltipData[1].querySelector('.value').textContent).toBe('30');
+
+                    expect(tooltipData[2].querySelector('.name').textContent).toBe('data3');
+                    expect(tooltipData[2].querySelector('.value').textContent).toBe('230');
+
+                    expect(tooltipData[3].querySelector('.name').textContent).toBe('data2');
+                    expect(tooltipData[3].querySelector('.value').textContent).toBe('130');
+
+                    moveMouse(146, 46);
+
+                    expect(document.querySelector('.c3-tooltip-container').style.display).toEqual('block');
+
+                    tooltipData = [...document.querySelectorAll('.c3-tooltip tr')];
+
+                    expect(tooltipData.length).toBe(4); // header + data[123]
+
+                    expect(tooltipData[1].querySelector('.name').textContent).toBe('data1');
+                    expect(tooltipData[1].querySelector('.value').textContent).toBe('200');
+
+                    expect(tooltipData[2].querySelector('.name').textContent).toBe('data3');
+                    expect(tooltipData[2].querySelector('.value').textContent).toBe('-200');
+
+                    expect(tooltipData[3].querySelector('.name').textContent).toBe('data2');
+                    expect(tooltipData[3].querySelector('.value').textContent).toBe('-100');
+                });
+            });
         });
     });
 

--- a/src/core.js
+++ b/src/core.js
@@ -88,7 +88,7 @@ ChartInternal.prototype.initParams = function() {
     $$.dragging = false;
     $$.flowing = false;
     $$.cancelClick = false;
-    $$.mouseover = false;
+    $$.mouseover = undefined;
     $$.transiting = false;
 
     $$.color = $$.generateColor();

--- a/src/data.js
+++ b/src/data.js
@@ -410,6 +410,18 @@ ChartInternal.prototype.orderTargets = function (targets) {
     }
     return targets;
 };
+
+/**
+ * Returns all the values from the given targets at the given index.
+ *
+ * @param {Array} targets
+ * @param {Number} index
+ * @return {Array}
+ */
+ChartInternal.prototype.filterByIndex = function (targets, index) {
+    return this.d3.merge(targets.map((t) => t.values.filter((v) => v.index === index)));
+};
+
 ChartInternal.prototype.filterByX = function (targets, x) {
     return this.d3.merge(targets.map(function (t) {
         return t.values;

--- a/src/data.js
+++ b/src/data.js
@@ -276,6 +276,19 @@ ChartInternal.prototype.isTargetToShow = function (targetId) {
 ChartInternal.prototype.isLegendToShow = function (targetId) {
     return this.hiddenLegendIds.indexOf(targetId) < 0;
 };
+
+/**
+ * Returns only visible targets.
+ *
+ * This is the same as calling {@link filterTargetsToShow} on $$.data.targets.
+ *
+ * @return {Array}
+ */
+ChartInternal.prototype.getTargetsToShow = function() {
+    const $$ = this;
+    return $$.filterTargetsToShow($$.data.targets);
+};
+
 ChartInternal.prototype.filterTargetsToShow = function (targets) {
     var $$ = this;
     return targets.filter(function (t) {

--- a/src/data.js
+++ b/src/data.js
@@ -536,8 +536,8 @@ ChartInternal.prototype.findClosest = function (dataPoints, pos, computeDist, mi
         .filter((v) => v && $$.isBarType(v.id))
         .forEach(function (v) {
             if (!closest) {
-                var shape = $$.main.select('.' + CLASS.bars + $$.getTargetSelectorSuffix(v.id) + ' .' + CLASS.bar + '-' + v.index).node();
-                if ($$.isWithinBar($$.d3.mouse(shape), shape)) {
+                const shape = $$.main.select('.' + CLASS.bars + $$.getTargetSelectorSuffix(v.id) + ' .' + CLASS.bar + '-' + v.index).node();
+                if ($$.isWithinBar(pos, shape)) {
                     closest = v;
                 }
             }

--- a/src/data.js
+++ b/src/data.js
@@ -488,43 +488,71 @@ ChartInternal.prototype.isArc = function (d) {
     return 'data' in d && this.hasTarget(this.data.targets, d.data.id);
 };
 
+/**
+ * Find the closest point from the given pos among the given targets or
+ * undefined if none satisfies conditions.
+ *
+ * @param {Array} targets
+ * @param {Array} pos An [x,y] coordinate
+ * @return {Object|undefined}
+ */
 ChartInternal.prototype.findClosestFromTargets = function (targets, pos) {
-    var $$ = this,
-        candidates;
+    const $$ = this;
 
-    // map to array of closest points of each target
-    candidates = targets.map(function (target) {
-        return $$.findClosest(target.values, pos);
-    });
+    // for each target, find the closest point
+    const candidates = targets
+        .map((t) => $$.findClosest(t.values, pos, $$.config.tooltip_horizontal ? $$.horizontalDistance.bind($$) : $$.dist.bind($$), $$.config.point_sensitivity))
+        .filter((v) => v);
 
-    // decide closest point and return
-    return $$.findClosest(candidates, pos);
+    // returns the closest of candidates
+    if (candidates.length === 0) {
+        return undefined;
+    } else if (candidates.length === 1) {
+        return candidates[0];
+    } else {
+        return $$.findClosest(candidates, pos, $$.dist.bind($$));
+    }
 };
-ChartInternal.prototype.findClosest = function (values, pos) {
-    var $$ = this,
-        minDist = $$.config.point_sensitivity,
-        closest;
 
-    // find mouseovering bar
-    values.filter(function (v) {
-        return v && $$.isBarType(v.id);
-    }).forEach(function (v) {
-        var shape = $$.main.select('.' + CLASS.bars + $$.getTargetSelectorSuffix(v.id) + ' .' + CLASS.bar + '-' + v.index).node();
-        if (!closest && $$.isWithinBar($$.d3.mouse(shape), shape)) {
-            closest = v;
-        }
-    });
+/**
+ * Using given compute distance method, returns the closest data point from the
+ * given position.
+ *
+ * Giving optionally a minimum distance to satisfy.
+ *
+ * @param {Array} dataPoints List of DataPoints
+ * @param {Array} pos An [x,y] coordinate
+ * @param {Function} computeDist Function to compute distance between 2 points
+ * @param {Number} minDist Minimal distance to satisfy
+ * @return {Object|undefined} Closest data point
+ */
+ChartInternal.prototype.findClosest = function (dataPoints, pos, computeDist, minDist = Infinity) {
+    const $$ = this;
+
+    let closest;
+
+    // find closest bar
+    dataPoints
+        .filter((v) => v && $$.isBarType(v.id))
+        .forEach(function (v) {
+            if (!closest) {
+                var shape = $$.main.select('.' + CLASS.bars + $$.getTargetSelectorSuffix(v.id) + ' .' + CLASS.bar + '-' + v.index).node();
+                if ($$.isWithinBar($$.d3.mouse(shape), shape)) {
+                    closest = v;
+                }
+            }
+        });
 
     // find closest point from non-bar
-    values.filter(function (v) {
-        return v && !$$.isBarType(v.id);
-    }).forEach(function (v) {
-        var d = $$.config.tooltip_horizontal ? $$.horizontalDistance(v, pos) : $$.dist(v, pos);
-        if (d < minDist) {
-            minDist = d;
-            closest = v;
-        }
-    });
+    dataPoints
+        .filter((v) => v && !$$.isBarType(v.id))
+        .forEach((v) => {
+            let d = computeDist(v, pos);
+            if (d < minDist) {
+                minDist = d;
+                closest = v;
+            }
+        });
 
     return closest;
 };

--- a/src/grid.js
+++ b/src/grid.js
@@ -210,8 +210,8 @@ ChartInternal.prototype.showXGridFocus = function (selectedData) {
         focusEl = $$.main.selectAll('line.' + CLASS.xgridFocus),
         xx = $$.xx.bind($$);
     if (! config.tooltip_show) { return; }
-    // Hide when scatter plot exists
-    if ($$.hasType('scatter') || $$.hasType('stanford') || $$.hasArcType()) { return; }
+    // Hide when stanford plot exists
+    if ($$.hasType('stanford') || $$.hasArcType()) { return; }
     focusEl
         .style("visibility", "visible")
         .data([dataToShow[0]])

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -51,6 +51,10 @@ ChartInternal.prototype.redrawEventRect = function () {
         .on('mouseout',  config.interaction_enabled ? function () {
             if (!config) { return; } // chart is destroyed
             if ($$.hasArcType()) { return; }
+            if ($$.mouseover){
+              config.data_onmouseout.call($$.api, $$.mouseover);
+              $$.mouseover = undefined;
+            }
             mouseout();
         } : null)
         .on('mousemove', config.interaction_enabled ? function () {

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -109,7 +109,7 @@ ChartInternal.prototype.redrawEventRect = function () {
             } else {
                 const mouseX = config.axis_rotated ? mouse[1] : mouse[0];
 
-                selectedData = $$.filterByX(targetsToShow, xEventScale(mouseX));
+                selectedData = $$.filterByIndex(targetsToShow, xEventScale(mouseX));
             }
 
             // inject names for each point

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -63,7 +63,7 @@ ChartInternal.prototype.redrawEventRect = function () {
             mouse = d3.mouse(this);
             closest = $$.findClosestFromTargets(targetsToShow, mouse);
 
-            if ($$.mouseover && (!closest || closest.id !== $$.mouseover.id)) {
+            if ($$.mouseover && (!closest || closest.id !== $$.mouseover.id || closest.index !== $$.mouseover.index)) {
                 config.data_onmouseout.call($$.api, $$.mouseover);
                 $$.mouseover = undefined;
             }

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -58,12 +58,14 @@ ChartInternal.prototype.redrawEventRect = function () {
             mouseout();
         } : null)
         .on('mousemove', config.interaction_enabled ? function () {
-            var targetsToShow, mouse, closest, sameXData, selectedData;
+            var mouse, closest, sameXData, selectedData;
 
             if ($$.dragging) { return; } // do nothing when dragging
+
+            const targetsToShow = $$.getTargetsToShow();
+
             if ($$.hasArcType(targetsToShow)) { return; }
 
-            targetsToShow = $$.filterTargetsToShow($$.data.targets);
             mouse = d3.mouse(this);
             closest = $$.findClosestFromTargets(targetsToShow, mouse);
 
@@ -111,10 +113,12 @@ ChartInternal.prototype.redrawEventRect = function () {
             }
         } : null)
         .on('click', config.interaction_enabled ? function () {
-            var targetsToShow, mouse, closest, sameXData;
+            var mouse, closest, sameXData;
+
+            const targetsToShow = $$.getTargetsToShow();
+
             if ($$.hasArcType(targetsToShow)) { return; }
 
-            targetsToShow = $$.filterTargetsToShow($$.data.targets);
             mouse = d3.mouse(this);
             closest = $$.findClosestFromTargets(targetsToShow, mouse);
             if (! closest) { return; }

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -96,7 +96,7 @@ ChartInternal.prototype.redrawEventRect = function () {
             $$.svg.select('.' + CLASS.eventRect).style('cursor', isMouseCloseToDataPoint ? 'pointer' :  null);
 
             // if tooltip not grouped, we want to display only data from closest data point
-            const showSingleDataPoint = !config.tooltip_grouped || $$.hasScatterOrStanfordType(targetsToShow);
+            const showSingleDataPoint = !config.tooltip_grouped || $$.hasType('stanford', targetsToShow);
 
             // find data to highlight
             let selectedData;
@@ -151,7 +151,7 @@ ChartInternal.prototype.redrawEventRect = function () {
 
             // select if selection enabled
             let sameXData;
-            if (!config.data_selection_grouped || $$.isScatterOrStanfordType(closest)) {
+            if (!config.data_selection_grouped || $$.isStanfordType(closest)) {
                 sameXData = [closest];
             } else {
                 sameXData = $$.filterByX(targetsToShow, closest.x);

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -157,14 +157,21 @@ ChartInternal.prototype.redrawEventRect = function () {
                 sameXData = $$.filterByX(targetsToShow, closest.x);
             }
 
+            // toggle selected state
             sameXData.forEach(function (d) {
                 $$.main.selectAll('.' + CLASS.shapes + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.shape + '-' + d.index).each(function () {
                     if (config.data_selection_grouped || $$.isWithinShape(this, d)) {
                         $$.toggleShape(this, d, d.index);
-                        config.data_onclick.call($$.api, d, this);
                     }
                 });
             });
+
+            // call data_onclick on the closest data point
+            if (closest) {
+                const shape = $$.main.selectAll('.' + CLASS.shapes + $$.getTargetSelectorSuffix(closest.id)).select('.' + CLASS.shape + '-' + closest.index);
+                config.data_onclick.call($$.api, closest, shape.node());
+            }
+
         } : null)
         .call(
             config.interaction_enabled && config.data_selection_draggable && $$.drag ? (

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -22,14 +22,7 @@ ChartInternal.prototype.initEventRect = function () {
     }
 };
 ChartInternal.prototype.redrawEventRect = function () {
-    var $$ = this, d3 = $$.d3, config = $$.config,
-        x, y, w, h;
-
-    // TODO: rotated not supported yet
-    x = 0;
-    y = 0;
-    w = $$.width;
-    h = $$.height;
+    const $$ = this, d3 = $$.d3, config = $$.config;
 
     function mouseout() {
         $$.svg.select('.' + CLASS.eventRect).style('cursor', null);
@@ -39,15 +32,30 @@ ChartInternal.prototype.redrawEventRect = function () {
         $$.unexpandBars();
     }
 
+    const isHoveringDataPoint = (mouse, closest) =>
+        closest && ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity);
+
+    // converts 'x' position (in pixel) to category index
+    const maxDataCount = $$.getMaxDataCount();
+
+    const xEventScale = d3.scaleQuantize()
+        // use X range (in pixel) as domain
+        .domain([0, config.axis_rotated ? $$.height : $$.width])
+        // 0 to N evenly distributed
+        .range(maxDataCount ? Array.apply(null, { length: maxDataCount }).map(Function.call, Number) : [0]);
+
+    const withName = (d) =>
+        d ? $$.addName(Object.assign({}, d)) : null;
+
     // rects for mouseover
     $$.main.select('.' + CLASS.eventRects)
         .style('cursor', config.zoom_enabled ? config.axis_rotated ? 'ns-resize' : 'ew-resize' : null);
 
     $$.eventRect
-        .attr('x', x)
-        .attr('y', y)
-        .attr('width', w)
-        .attr('height', h)
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('width', $$.width)
+        .attr('height', $$.height)
         .on('mouseout',  config.interaction_enabled ? function () {
             if (!config) { return; } // chart is destroyed
             if ($$.hasArcType()) { return; }
@@ -58,37 +66,56 @@ ChartInternal.prototype.redrawEventRect = function () {
             mouseout();
         } : null)
         .on('mousemove', config.interaction_enabled ? function () {
-            var mouse, closest, sameXData, selectedData;
-
-            if ($$.dragging) { return; } // do nothing when dragging
+            // do nothing when dragging
+            if ($$.dragging) {
+                return;
+            }
 
             const targetsToShow = $$.getTargetsToShow();
 
-            if ($$.hasArcType(targetsToShow)) { return; }
+            // do nothing if arc type
+            if ($$.hasArcType(targetsToShow)) {
+                return;
+            }
 
-            mouse = d3.mouse(this);
-            closest = $$.findClosestFromTargets(targetsToShow, mouse);
+            const mouse = d3.mouse(this);
+            const closest = withName($$.findClosestFromTargets(targetsToShow, mouse));
+            const isMouseCloseToDataPoint = isHoveringDataPoint(mouse, closest);
 
+            // ensure onmouseout is always called if mousemove switch between 2 targets
             if ($$.mouseover && (!closest || closest.id !== $$.mouseover.id || closest.index !== $$.mouseover.index)) {
                 config.data_onmouseout.call($$.api, $$.mouseover);
                 $$.mouseover = undefined;
             }
-
-            if (!closest) {
-                mouseout();
-                return;
+            if (closest && !$$.mouseover) {
+                config.data_onmouseover.call($$.api, closest);
+                $$.mouseover = closest;
             }
 
-            if ($$.isScatterOrStanfordType(closest) || !config.tooltip_grouped) {
-                sameXData = [closest];
+            // show cursor as pointer if we're hovering a data point close enough
+            $$.svg.select('.' + CLASS.eventRect).style('cursor', isMouseCloseToDataPoint ? 'pointer' :  null);
+
+            // if tooltip not grouped, we want to display only data from closest data point
+            const showSingleDataPoint = !config.tooltip_grouped || $$.hasScatterOrStanfordType(targetsToShow);
+
+            // find data to highlight
+            let selectedData;
+            if (showSingleDataPoint) {
+                if (!closest) {
+                    return mouseout();
+                }
+
+                selectedData = [closest];
             } else {
-                sameXData = $$.filterByX(targetsToShow, closest.x);
+                const mouseX = config.axis_rotated ? mouse[1] : mouse[0];
+
+                selectedData = $$.filterByX(targetsToShow, xEventScale(mouseX));
             }
 
-            // show tooltip when cursor is close to some point
-            selectedData = sameXData.map(function (d) {
-                return $$.addName(d);
-            });
+            // inject names for each point
+            selectedData = selectedData.map(withName);
+
+            // show tooltip
             $$.showTooltip(selectedData, this);
 
             // expand points
@@ -98,46 +125,46 @@ ChartInternal.prototype.redrawEventRect = function () {
                     $$.expandCircles(d.index, d.id, false);
                 });
             }
-            $$.expandBars(closest.index, closest.id, true);
+
+            // expand bars
+            $$.unexpandBars();
+            selectedData.forEach(function (d) {
+                $$.expandBars(d.index, d.id, false);
+            });
 
             // Show xgrid focus line
             $$.showXGridFocus(selectedData);
-
-            // Show cursor as pointer if point is close to mouse position
-            if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity) {
-                $$.svg.select('.' + CLASS.eventRect).style('cursor', 'pointer');
-                if (!$$.mouseover) {
-                    config.data_onmouseover.call($$.api, closest);
-                    $$.mouseover = closest;
-                }
-            }
         } : null)
         .on('click', config.interaction_enabled ? function () {
-            var mouse, closest, sameXData;
-
             const targetsToShow = $$.getTargetsToShow();
 
-            if ($$.hasArcType(targetsToShow)) { return; }
-
-            mouse = d3.mouse(this);
-            closest = $$.findClosestFromTargets(targetsToShow, mouse);
-            if (! closest) { return; }
-            // select if selection enabled
-            if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity) {
-                if ($$.isScatterOrStanfordType(closest) || !config.data_selection_grouped) {
-                    sameXData = [closest];
-                } else {
-                    sameXData = $$.filterByX(targetsToShow, closest.x);
-                }
-                sameXData.forEach(function (d) {
-                    $$.main.selectAll('.' + CLASS.shapes + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.shape + '-' + d.index).each(function () {
-                        if (config.data_selection_grouped || $$.isWithinShape(this, d)) {
-                            $$.toggleShape(this, d, d.index);
-                            config.data_onclick.call($$.api, d, this);
-                        }
-                    });
-                });
+            if ($$.hasArcType(targetsToShow)) {
+                return;
             }
+
+            const mouse = d3.mouse(this);
+            const closest = withName($$.findClosestFromTargets(targetsToShow, mouse));
+
+            if (!isHoveringDataPoint(mouse, closest)) {
+                return;
+            }
+
+            // select if selection enabled
+            let sameXData;
+            if (!config.data_selection_grouped || $$.isScatterOrStanfordType(closest)) {
+                sameXData = [closest];
+            } else {
+                sameXData = $$.filterByX(targetsToShow, closest.x);
+            }
+
+            sameXData.forEach(function (d) {
+                $$.main.selectAll('.' + CLASS.shapes + $$.getTargetSelectorSuffix(d.id)).selectAll('.' + CLASS.shape + '-' + d.index).each(function () {
+                    if (config.data_selection_grouped || $$.isWithinShape(this, d)) {
+                        $$.toggleShape(this, d, d.index);
+                        config.data_onclick.call($$.api, d, this);
+                    }
+                });
+            });
         } : null)
         .call(
             config.interaction_enabled && config.data_selection_draggable && $$.drag ? (

--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -1,6 +1,6 @@
 import CLASS from './class';
 import { ChartInternal } from './core';
-import { getBBox, isValue } from './util';
+import { getBBox, isValue, isWithinBox } from './util';
 
 ChartInternal.prototype.initBar = function () {
     var $$ = this;
@@ -119,14 +119,14 @@ ChartInternal.prototype.generateGetBarPoints = function (barIndices, isSub) {
         ];
     };
 };
-ChartInternal.prototype.isWithinBar = function (mouse, that) {
-    if (that.pathSegList.numberOfItems < 2) {
-        return false;
-    }
-    var box = getBBox(that),
-        seg0 = that.pathSegList.getItem(0), seg1 = that.pathSegList.getItem(1),
-        x = Math.min(seg0.x, seg1.x), y = Math.min(seg0.y, seg1.y),
-        w = box.width, h = box.height, offset = 2,
-        sx = x - offset, ex = x + w + offset, sy = y + h + offset, ey = y - offset;
-    return sx < mouse[0] && mouse[0] < ex && ey < mouse[1] && mouse[1] < sy;
+
+/**
+ * Returns whether the data point is within the given bar shape.
+ *
+ * @param mouse
+ * @param barShape
+ * @return {boolean}
+ */
+ChartInternal.prototype.isWithinBar = function (mouse, barShape) {
+    return isWithinBox(mouse, getBBox(barShape), 2);
 };

--- a/src/type.js
+++ b/src/type.js
@@ -33,9 +33,6 @@ ChartInternal.prototype.hasType = function (type, targets) {
 ChartInternal.prototype.hasArcType = function (targets) {
     return this.hasType('pie', targets) || this.hasType('donut', targets) || this.hasType('gauge', targets);
 };
-ChartInternal.prototype.hasScatterOrStanfordType = function(targets) {
-  return this.hasType('scatter', targets) || this.hasType('stanford', targets);
-};
 ChartInternal.prototype.isLineType = function (d) {
     var config = this.config, id = isString(d) ? d : d.id;
     return !config.data_types[id] || ['line', 'spline', 'area', 'area-spline', 'step', 'area-step'].indexOf(config.data_types[id]) >= 0;
@@ -63,9 +60,6 @@ ChartInternal.prototype.isScatterType = function (d) {
 ChartInternal.prototype.isStanfordType = function (d) {
     var id = isString(d) ? d : d.id;
     return this.config.data_types[id] === 'stanford';
-};
-ChartInternal.prototype.isScatterOrStanfordType = function (d) {
-    return this.isScatterType(d) || this.isStanfordType(d);
 };
 ChartInternal.prototype.isPieType = function (d) {
     var id = isString(d) ? d : d.id;

--- a/src/type.js
+++ b/src/type.js
@@ -33,6 +33,9 @@ ChartInternal.prototype.hasType = function (type, targets) {
 ChartInternal.prototype.hasArcType = function (targets) {
     return this.hasType('pie', targets) || this.hasType('donut', targets) || this.hasType('gauge', targets);
 };
+ChartInternal.prototype.hasScatterOrStanfordType = function(targets) {
+  return this.hasType('scatter', targets) || this.hasType('stanford', targets);
+};
 ChartInternal.prototype.isLineType = function (d) {
     var config = this.config, id = isString(d) ? d : d.id;
     return !config.data_types[id] || ['line', 'spline', 'area', 'area-spline', 'step', 'area-step'].indexOf(config.data_types[id]) >= 0;

--- a/src/util.js
+++ b/src/util.js
@@ -71,3 +71,19 @@ export var sanitise = function(str) {
 export var flattenArray = function(arr) {
     return Array.isArray(arr) ? [].concat(...arr) : [];
 };
+/**
+ * Returns whether the point is within the given box.
+ *
+ * @param {Array} point An [x,y] coordinate
+ * @param {Object} box An object with {x, y, width, height} keys
+ * @param {Number} sensitivity An offset to ease check on very small boxes
+ */
+export var isWithinBox = function(point, box, sensitivity = 0) {
+    const xStart = box.x - sensitivity;
+    const xEnd = box.x + box.width + sensitivity;
+    const yStart = box.y + box.height + sensitivity;
+    const yEnd = box.y - sensitivity;
+
+    return xStart < point[0] && point[0] < xEnd && yEnd < point[1] && point[1] < yStart;
+};
+


### PR DESCRIPTION
In previous version of `c3js` when `tooltip_grouped` was true, the simple act of hovering above a category would highlight/show the data point(s) of that particular category.

But it was broken when c3js started to use a single rect for the whole chart.

This PR aims to restore this important behavior.

It also includes the fix proposed in #2151.

Closes #2362
Closes #1745
Closes #2641
Closes #1201

It removes one of the usage of pathSegList (#2075)


Left to do:

- [x] Add tests for timeseries