### PR TITLE
more cache hits for getMaxTickWidth

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -138,12 +138,6 @@ ChartInternal.prototype.initParams = function() {
     $$.legendItemWidth = 0;
     $$.legendItemHeight = 0;
 
-    $$.currentMaxTickWidths = {
-        x: 0,
-        y: 0,
-        y2: 0
-    };
-
     $$.rotated_padding_left = 30;
     $$.rotated_padding_right = config.axis_rotated && !config.axis_x_show ? 0 : 30;
     $$.rotated_padding_top = 5;
@@ -533,6 +527,9 @@ ChartInternal.prototype.redraw = function(options, transitions) {
     durationForExit = withTransitionForExit ? duration : 0;
     durationForAxis = withTransitionForAxis ? duration : 0;
 
+    // reset caches when we are re-drawing the chart
+    $$.resetCache();
+
     transitions = transitions || $$.axis.generateTransitions(durationForAxis);
 
     // update legend and transform each g
@@ -762,6 +759,8 @@ ChartInternal.prototype.updateAndRedraw = function(options) {
     options.withUpdateOrgXDomain = getOption(options, "withUpdateOrgXDomain", true);
     options.withTransitionForExit = false;
     options.withTransitionForTransform = getOption(options, "withTransitionForTransform", options.withTransition);
+    // clear any cache before we update sizes
+    $$.resetCache();
     // MEMO: this needs to be called before updateLegend and it means this ALWAYS needs to be called)
     $$.updateSizes();
     // MEMO: called in updateLegend in redraw if withLegend
@@ -1148,7 +1147,7 @@ ChartInternal.prototype.generateWait = function() {
                 if (!$$.isTabVisible()) {
                   return;
                 }
-  
+
                 var done = 0;
                 transitionsToWait.forEach(function(t) {
                     if (t.empty()) {

--- a/src/size.js
+++ b/src/size.js
@@ -24,16 +24,16 @@ ChartInternal.prototype.getCurrentPaddingBottom = function () {
     var config = this.config;
     return isValue(config.padding_bottom) ? config.padding_bottom : 0;
 };
-ChartInternal.prototype.getCurrentPaddingLeft = function (withoutRecompute) {
+ChartInternal.prototype.getCurrentPaddingLeft = function () {
     var $$ = this, config = $$.config;
     if (isValue(config.padding_left)) {
         return config.padding_left;
     } else if (config.axis_rotated) {
-        return (!config.axis_x_show || config.axis_x_inner) ? 1 : Math.max(ceil10($$.getAxisWidthByAxisId('x', withoutRecompute)), 40);
+        return (!config.axis_x_show || config.axis_x_inner) ? 1 : Math.max(ceil10($$.getAxisWidthByAxisId('x')), 40);
     } else if (!config.axis_y_show || config.axis_y_inner) { // && !config.axis_rotated
         return $$.axis.getYAxisLabelPosition().isOuter ? 30 : 1;
     } else {
-        return ceil10($$.getAxisWidthByAxisId('y', withoutRecompute));
+        return ceil10($$.getAxisWidthByAxisId('y'));
     }
 };
 ChartInternal.prototype.getCurrentPaddingRight = function () {
@@ -85,7 +85,7 @@ ChartInternal.prototype.getParentHeight = function () {
 };
 
 
-ChartInternal.prototype.getSvgLeft = function (withoutRecompute) {
+ChartInternal.prototype.getSvgLeft = function () {
     var $$ = this, config = $$.config,
         hasLeftAxisRect = config.axis_rotated || (!config.axis_rotated && !config.axis_y_inner),
         leftAxisClass = config.axis_rotated ? CLASS.axisX : CLASS.axisY,
@@ -93,14 +93,14 @@ ChartInternal.prototype.getSvgLeft = function (withoutRecompute) {
         svgRect = leftAxis && hasLeftAxisRect ? leftAxis.getBoundingClientRect() : {right: 0},
         chartRect = $$.selectChart.node().getBoundingClientRect(),
         hasArc = $$.hasArcType(),
-        svgLeft = svgRect.right - chartRect.left - (hasArc ? 0 : $$.getCurrentPaddingLeft(withoutRecompute));
+        svgLeft = svgRect.right - chartRect.left - (hasArc ? 0 : $$.getCurrentPaddingLeft());
     return svgLeft > 0 ? svgLeft : 0;
 };
 
 
-ChartInternal.prototype.getAxisWidthByAxisId = function (id, withoutRecompute) {
+ChartInternal.prototype.getAxisWidthByAxisId = function (id) {
     var $$ = this, position = $$.axis.getLabelPositionById(id);
-    return $$.axis.getMaxTickWidth(id, withoutRecompute) + (position.isInner ? 20 : 40);
+    return $$.axis.getMaxTickWidth(id) + (position.isInner ? 20 : 40);
 };
 ChartInternal.prototype.getHorizontalAxisHeight = function (axisId) {
     var $$ = this, config = $$.config, h = 30;


### PR DESCRIPTION
This PR:

- removes `withoutRecompute` and always return cached version if exists
- reuse `addToCache` and `getFromCache` instead of custom property
- add call to `resetCache` when `redraw` is called.

This way we have  more cache hits and the cache is dropped each time we want to redraw the chart (thinking of resize etc.) which should be, hopefully, sufficient.
