### PR TITLE
only set shape-rendering for standard graph type

### DIFF
--- a/src/shape.line.js
+++ b/src/shape.line.js
@@ -308,7 +308,7 @@ ChartInternal.prototype.updateCircle = function (cx, cy) {
         .data($$.lineOrScatterOrStanfordData.bind($$));
 
     var mainCircleEnter = mainCircle.enter().append("circle")
-        .attr('shape-rendering', 'crispEdges')
+        .attr('shape-rendering', $$.isStanfordGraphType() ? 'crispEdges' : '')
         .attr("class", $$.classCircle.bind($$))
         .attr("cx", cx)
         .attr("cy", cy)


### PR DESCRIPTION
The "shape-rendering" was introduced with the stanford graph type but it makes the scatter appears really .... not sharp.

This PR  make it so that the `crispEdges` is only set for stanford.

Closes #2689 