### PR TITLE
Style empty points in line charts via CSS

### DIFF
--- a/src/scss/point.scss
+++ b/src/scss/point.scss
@@ -1,3 +1,6 @@
+.c3-circle {
+  fill: currentColor;
+}
 .c3-circle._expanded_ {
   stroke-width: 1px;
   stroke: white;

--- a/src/shape.line.js
+++ b/src/shape.line.js
@@ -313,7 +313,7 @@ ChartInternal.prototype.updateCircle = function (cx, cy) {
         .attr("cx", cx)
         .attr("cy", cy)
         .attr("r", $$.pointR.bind($$))
-        .style("fill", $$.isStanfordGraphType() ? $$.getStanfordPointColor.bind($$) : $$.color);
+        .style("color", $$.isStanfordGraphType() ? $$.getStanfordPointColor.bind($$) : $$.color);
 
     $$.mainCircle = mainCircleEnter.merge(mainCircle)
         .style("opacity", $$.isStanfordGraphType() ? 1 : $$.initialOpacityForCircle.bind($$));
@@ -327,7 +327,7 @@ ChartInternal.prototype.redrawCircle = function (cx, cy, withTransition, transit
     return [
         (withTransition ? $$.mainCircle.transition(transition) : $$.mainCircle)
             .style('opacity', this.opacityForCircle.bind($$))
-            .style("fill", $$.isStanfordGraphType() ? $$.getStanfordPointColor.bind($$) : $$.color)
+            .style("color", $$.isStanfordGraphType() ? $$.getStanfordPointColor.bind($$) : $$.color)
             .attr("cx", cx)
             .attr("cy", cy),
         (withTransition ? selectedCircles.transition(transition) : selectedCircles)


### PR DESCRIPTION
An up to date version of #1992

I'll merge this in my fork because it looks neat, I'll leave you to decide if you want this in the main repository.

The culprit is that `currentColor` is not supported by IE8, in my case I do not care, maybe some will.

Although I'm not sure how well IE8 is supported at the moment (maybe not at all.).
