### PR TITLE
correct initial visibility of hidden bars

### DIFF
--- a/src/shape.bar.js
+++ b/src/shape.bar.js
@@ -43,12 +43,14 @@ ChartInternal.prototype.updateBar = function (durationForExit) {
         .style("opacity", 0);
 };
 ChartInternal.prototype.redrawBar = function (drawBar, withTransition, transition) {
+    const $$ = this;
+
     return [
         (withTransition ? this.mainBar.transition(transition) : this.mainBar)
             .attr('d', drawBar)
             .style("stroke", this.color)
             .style("fill", this.color)
-            .style("opacity", 1)
+            .style("opacity", (d) => $$.isTargetToShow(d.id) ? 1 : 0)
     ];
 };
 ChartInternal.prototype.getBarW = function (axis, barTargetsNum) {


### PR DESCRIPTION
When using 'data_hide' option, the bars are not taken into account when
computing offsets and so on but they still have 'opacity:1'.

There is another issue that I have no time to really dig into is that the order of targets (given to the legend) may changes when you toggle back the initially hidden series, visible with the `c3 chart interaction bar chart tooltip_grouped=true expands all bars of currently hovered category` test.

Closes #2685 
