### PR TITLE
add polyfill for Object.assign as it is not supported by IE11

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1612,4 +1612,36 @@ if (!String.prototype.padEnd) {
     };
 }
 
+// Object.assign polyfill for IE11
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+if (typeof Object.assign !== 'function') {
+    // Must be writable: true, enumerable: false, configurable: true
+    Object.defineProperty(Object, "assign", {
+        value: function assign(target, varArgs) { // .length of function is 2
+            'use strict';
+            if (target === null || target === undefined) {
+                throw new TypeError('Cannot convert undefined or null to object');
+            }
+
+            var to = Object(target);
+
+            for (var index = 1; index < arguments.length; index++) {
+                var nextSource = arguments[index];
+
+                if (nextSource !== null && nextSource !== undefined) {
+                    for (var nextKey in nextSource) {
+                        // Avoid bugs when hasOwnProperty is shadowed
+                        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                            to[nextKey] = nextSource[nextKey];
+                        }
+                    }
+                }
+            }
+            return to;
+        },
+        writable: true,
+        configurable: true
+    });
+}
+
 /* jshint ignore:end */


### PR DESCRIPTION
Closes #2708

I took the path of adding the polyfill directly because this is 20L of codes and moving forward this is very likely that we (or at least I) use 'assign' out of habit here and there when I need a shallow copy.