### PR TITLE
Add an ES6 module output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ components
 # build
 /htdocs/js/c3.js
 /htdocs/js/c3.min.js
+/htdocs/js/c3.esm.js
 /htdocs/css/c3.css
 /htdocs/css/c3.min.css
 /build

--- a/package-lock.json
+++ b/package-lock.json
@@ -5724,6 +5724,15 @@
         "yallist": "^2.1.2"
       }
     },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -6385,6 +6394,15 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "ospec": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ospec/-/ospec-3.1.0.tgz",
+      "integrity": "sha512-+nGtjV3vlADp+UGfL51miAh/hB4awPBkQrArhcgG4trAaoA2gKt5bf9w0m9ch9zOr555cHWaCHZEDiBOkNZSxw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "outpipe": {
       "version": "1.1.1",
@@ -7085,6 +7103,16 @@
         "rollup-pluginutils": "^2.3.0"
       }
     },
+    "rollup-plugin-modify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-modify/-/rollup-plugin-modify-3.0.0.tgz",
+      "integrity": "sha512-p/ffs0Y2jz2dEnWjq1oVC7SY37tuS+aP7whoNaQz1EAAOPg+k3vKJo8cMMWx6xpdd0NzhX4y2YF9o/NPu5YR0Q==",
+      "dev": true,
+      "requires": {
+        "magic-string": "0.25.2",
+        "ospec": "3.1.0"
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
@@ -7501,6 +7529,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.7.tgz",
+      "integrity": "sha512-RuN23NzhAOuUtaivhcrjXx1OPXsFeH9m5sI373/U7+tGLKihjUyboZAzOadytMjnqHp1f45RGk1IzDKCpDpSYA==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.7.11",
   "description": "D3-based reusable chart library",
   "main": "c3.js",
+  "module": "c3.esm.js",
   "files": [
     "c3.js",
     "c3.min.js",
+    "c3.esm.js",
     "c3.css",
     "c3.min.css",
     "src"
@@ -78,6 +80,7 @@
     "npm-run-all": "^4.1.3",
     "rollup": "^1.27.4",
     "rollup-plugin-babel": "^4.0.3",
+    "rollup-plugin-modify": "^3.0.0",
     "sass": "^1.10.3",
     "status-back": "^1.1.0",
     "uglify-js": "^3.6.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,8 @@
 import babel from 'rollup-plugin-babel';
+import modify from 'rollup-plugin-modify';
 import pkg from './package.json'
 
-export default {
+export default [{
     input: 'src/index.js',
     output: {
         file: 'htdocs/js/c3.js',
@@ -18,4 +19,18 @@ export default {
         }]]
     })],
     external: ['d3'],
-};
+},{
+    input: 'src/index.js',
+    output: {
+        file: 'htdocs/js/c3.esm.js',
+        name: 'c3',
+        format: 'es',
+        banner: `/* @license C3.js v${pkg.version} | (c) C3 Team and other contributors | http://c3js.org/ */`,
+        intro: `import * as d3 from 'd3';`,
+    },
+    plugins: [modify({
+        find: /\$\$\.d3 =.+?;/,
+        replace: '$$.d3 = d3;'
+    })],
+    external: ['d3'],
+}];


### PR DESCRIPTION
To use C3 in modern bundlers such as Rollup, an ES6 module build should be provided. Since the whole code is already in ES6 module form and Rollup supports the `'es'` output target natively, this is a relative straight-forward addition.

This PR adds a second build output that is an ES6 module, which imports the D3 library internally and does not rely on a global `window.d3` configuration.

I have successfully tested this in a Svelte project of mine with Rollup.