### PR TITLE
Make legend toggle work in IE11

### DIFF
--- a/spec/util-spec.js
+++ b/spec/util-spec.js
@@ -14,7 +14,9 @@ import {
     notEmpty,
     sanitise,
     isNumber,
-    flattenArray
+    flattenArray,
+    getIEVersion,
+    isIE
 } from '../src/util';
 
 describe('util.js tests', function () {
@@ -211,6 +213,17 @@ describe('util.js tests', function () {
         });
         it('notEmpty should return true for nonempty_string', function () {
             expect(notEmpty(nonempty_string)).toBe(true);
+        });
+
+    });
+
+    describe('getIEVersion and isIE', function () {
+
+        it('getIEVersion should return a number or false', function () {
+            expect(getIEVersion()).toMatch(/(\d+|false)/);
+        });
+        it('isIE should return true or false', function () {
+            expect(isIE()).toMatch(/(true|false)/);
         });
 
     });

--- a/spec/util-spec.js
+++ b/spec/util-spec.js
@@ -219,10 +219,23 @@ describe('util.js tests', function () {
 
     describe('getIEVersion and isIE', function () {
 
-        it('getIEVersion should return a number or false', function () {
+        it('getIEVersion should return 10 for user agent string "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"', function () {
+            expect(getIEVersion('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)')).toBe(10);
+        });
+        it('getIEVersion should return 11 for user agent string "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"', function () {
+            expect(getIEVersion('Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko')).toBe(11);
+        });
+        it('getIEVersion should return false for user agent string "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0"', function () {
+            expect(getIEVersion('Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0')).toBe(false);
+        });
+        it('getIEVersion should return a number or false if parameter "agent" is not used', function () {
             expect(getIEVersion()).toMatch(/(\d+|false)/);
         });
-        it('isIE should return true or false', function () {
+
+        it('isIE should return false for version number 6', function () {
+            expect(isIE(6)).toMatch(/(true|false)/);
+        });
+        it('isIE should return true or false if parameter "version" is not used', function () {
             expect(isIE()).toMatch(/(true|false)/);
         });
 

--- a/src/api.show.js
+++ b/src/api.show.js
@@ -10,7 +10,7 @@ Chart.prototype.show = function (targetIds, options) {
     targets = $$.svg.selectAll($$.selectorTargets(targetIds));
 
     targets.transition()
-        .style('display', 'initial', 'important')
+        .style('display', 'block', 'important')
         .style('opacity', 1, 'important')
         .call($$.endall, function () {
             targets.style('opacity', null).style('opacity', 1);

--- a/src/api.show.js
+++ b/src/api.show.js
@@ -1,4 +1,5 @@
 import { Chart } from './core';
+import { isIE } from './util';
 
 Chart.prototype.show = function (targetIds, options) {
     var $$ = this.internal, targets;
@@ -10,7 +11,7 @@ Chart.prototype.show = function (targetIds, options) {
     targets = $$.svg.selectAll($$.selectorTargets(targetIds));
 
     targets.transition()
-        .style('display', 'block', 'important')
+        .style('display', isIE() ? 'block' : 'initial', 'important')
         .style('opacity', 1, 'important')
         .call($$.endall, function () {
             targets.style('opacity', null).style('opacity', 1);

--- a/src/util.js
+++ b/src/util.js
@@ -89,10 +89,14 @@ export var isWithinBox = function(point, box, sensitivity = 0) {
 
 /**
  * Returns Internet Explorer version number (or false if no Internet Explorer used).
+ *
+ * @param string agent Optional parameter to specify user agent
  */
-export var getIEVersion = function() {
+export var getIEVersion = function(agent) {
     // https://stackoverflow.com/questions/19999388/check-if-user-is-using-ie
-    const agent = window.navigator.userAgent;
+    if (typeof agent === 'undefined') {
+        agent = window.navigator.userAgent;
+    }
 
     let pos = agent.indexOf('MSIE '); // up to IE10
     if (pos > 0) {

--- a/src/util.js
+++ b/src/util.js
@@ -87,3 +87,38 @@ export var isWithinBox = function(point, box, sensitivity = 0) {
     return xStart < point[0] && point[0] < xEnd && yEnd < point[1] && point[1] < yStart;
 };
 
+/**
+ * Returns Internet Explorer version number (or false if no Internet Explorer used).
+ */
+export var getIEVersion = function() {
+    // https://stackoverflow.com/questions/19999388/check-if-user-is-using-ie
+    const agent = window.navigator.userAgent;
+
+    let pos = agent.indexOf('MSIE '); // up to IE10
+    if (pos > 0) {
+        return parseInt(agent.substring(pos + 5, agent.indexOf('.', pos)), 10);
+    }
+
+    pos = agent.indexOf('Trident/'); // IE11
+    if (pos > 0) {
+        pos = agent.indexOf('rv:');
+        return parseInt(agent.substring(pos + 3, agent.indexOf('.', pos)), 10);
+    }
+
+    return false;
+};
+
+/**
+ * Returns whether the used browser is Internet Explorer.
+ *
+ * @param {Number} version Optional parameter to specify IE version
+ */
+export var isIE = function(version) {
+    const ver = getIEVersion();
+
+    if (typeof version === 'undefined') {
+        return !!ver;
+    }
+
+    return version === ver;
+};


### PR DESCRIPTION
- Replaced ```display: initial``` by ```display: block``` in Chart.prototype.show() to stop hidden data items from disappearing in IE11 when they should be shown again (as described in #2528).
- Built and tested the changes locally and run tests according to contributing guide.
- Did not add new tests; if I should do that here, please give me a pointer on how it is done in this case.