### PR TITLE
Use util function to detect IE9 in getClipPath()

### DIFF
--- a/spec/util-spec.js
+++ b/spec/util-spec.js
@@ -233,7 +233,7 @@ describe('util.js tests', function () {
         });
 
         it('isIE should return false for version number 6', function () {
-            expect(isIE(6)).toMatch(/(true|false)/);
+            expect(isIE(6)).toBe(false);
         });
         it('isIE should return true or false if parameter "version" is not used', function () {
             expect(isIE()).toMatch(/(true|false)/);

--- a/src/clip.js
+++ b/src/clip.js
@@ -1,8 +1,8 @@
 import { ChartInternal } from './core';
+import { isIE } from './util';
 
 ChartInternal.prototype.getClipPath = function (id) {
-    var isIE9 = window.navigator.appVersion.toLowerCase().indexOf("msie 9.") >= 0;
-    return "url(" + (isIE9 ? "" : document.URL.split('#')[0]) + "#" + id + ")";
+    return "url(" + (isIE(9) ? "" : document.URL.split('#')[0]) + "#" + id + ")";
 };
 ChartInternal.prototype.appendClip = function (parent, id) {
     return parent.append("clipPath").attr("id", id).append("rect");


### PR DESCRIPTION
- replaced local IE9 detection by using `isIE(9)` from util.js
- corrected unit test for `isIE(6)` to check return value being `false`