### PR TITLE
Fix esm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.7.12",
   "description": "D3-based reusable chart library",
   "main": "c3.js",
-  "module": "c3.esm.js",
   "files": [
     "c3.js",
     "c3.min.js",


### PR DESCRIPTION
This PR tries to fix https://github.com/c3js/c3/issues/2747

- Webpack seems first trying to look up the entrypoint from `module` field instead of `main` field if it's present.

rollup users are still able to do `import c3 from 'c3/c3.esm'`