### PR TITLE
typo in documentation

### DIFF
--- a/docs/reference.html.haml
+++ b/docs/reference.html.haml
@@ -4144,7 +4144,7 @@
               \// Load data1 and unload data2 and data3
               chart.load({
               &nbsp;&nbsp;columns: [
-              &nbsp;&nbsp;&nbsp;&nbsp;['data1, 100, 200, 150, ...],
+              &nbsp;&nbsp;&nbsp;&nbsp;['data1', 100, 200, 150, ...],
               &nbsp;&nbsp;&nbsp;&nbsp;...
               &nbsp;&nbsp;],
               &nbsp;&nbsp;unload: ['data2', 'data3']


### PR DESCRIPTION
missing closing single quote. 

Im following documentation and found this typo here: https://c3js.org/reference.html#api-load

<!--

Thank you for contributing!

Please make sure to:
 
- provide tests with your code changes to ensure they are working as expected.
- not commit any of the distribution file (`c3.js`, `c3.css`, `c3.min.js`, `c3.min.css`).

-->
