### PR TITLE
docs: Fix simple typo, upated -> updated

### DIFF
--- a/c3.esm.js
+++ b/c3.esm.js
@@ -7954,7 +7954,7 @@ ChartInternal.prototype.initLegend = function () {
         return;
     }
     // MEMO: call here to update legend box and tranlate for all
-    // MEMO: translate will be upated by this, so transform not needed in updateLegend()
+    // MEMO: translate will be updated by this, so transform not needed in updateLegend()
     $$.updateLegendWithDefaults();
 };
 ChartInternal.prototype.updateLegendWithDefaults = function () {

--- a/c3.js
+++ b/c3.js
@@ -8952,7 +8952,7 @@
       $$.hiddenLegendIds = $$.mapToIds($$.data.targets);
       return;
     } // MEMO: call here to update legend box and tranlate for all
-    // MEMO: translate will be upated by this, so transform not needed in updateLegend()
+    // MEMO: translate will be updated by this, so transform not needed in updateLegend()
 
 
     $$.updateLegendWithDefaults();

--- a/docs/js/c3.esm.js
+++ b/docs/js/c3.esm.js
@@ -7954,7 +7954,7 @@ ChartInternal.prototype.initLegend = function () {
         return;
     }
     // MEMO: call here to update legend box and tranlate for all
-    // MEMO: translate will be upated by this, so transform not needed in updateLegend()
+    // MEMO: translate will be updated by this, so transform not needed in updateLegend()
     $$.updateLegendWithDefaults();
 };
 ChartInternal.prototype.updateLegendWithDefaults = function () {

--- a/docs/js/c3.js
+++ b/docs/js/c3.js
@@ -8952,7 +8952,7 @@
       $$.hiddenLegendIds = $$.mapToIds($$.data.targets);
       return;
     } // MEMO: call here to update legend box and tranlate for all
-    // MEMO: translate will be upated by this, so transform not needed in updateLegend()
+    // MEMO: translate will be updated by this, so transform not needed in updateLegend()
 
 
     $$.updateLegendWithDefaults();

--- a/src/legend.js
+++ b/src/legend.js
@@ -13,7 +13,7 @@ ChartInternal.prototype.initLegend = function() {
     return
   }
   // MEMO: call here to update legend box and tranlate for all
-  // MEMO: translate will be upated by this, so transform not needed in updateLegend()
+  // MEMO: translate will be updated by this, so transform not needed in updateLegend()
   $$.updateLegendWithDefaults()
 }
 ChartInternal.prototype.updateLegendWithDefaults = function() {


### PR DESCRIPTION
There is a small typo in c3.esm.js, c3.js, docs/js/c3.esm.js, docs/js/c3.js, src/legend.js.

Should read `updated` rather than `upated`.

