### PR TITLE
hide the previous tooltip in case of null value

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -270,6 +270,7 @@ ChartInternal.prototype.showTooltip = function(selectedData, element) {
     positionFunction =
       config.tooltip_position || ChartInternal.prototype.tooltipPosition
   if (dataToShow.length === 0 || !config.tooltip_show) {
+    $$.hideTooltip();
     return
   }
   $$.tooltip


### PR DESCRIPTION
I am developing a bar graph in which it is necessary to differentiate the values of the "x" axis that have the value 0 or that simply there is no value for that position.

Since c3js does not support the use of "undefined" values, I am using a "null" to represent that there is no value on the "x" axis.

The problem comes when you have the mouse over a bar with a value and when you move the mouse over a bar that has no value, the tooltip of the previous bar remains visible.

The behavior that c3js currently has when rendering tooltips is somewhat visually confusing, as the position marked by the mouse is not clear.