### PR TITLE
Removing pre filter on drag and applying it while points traversal

### DIFF
--- a/src/drag.js
+++ b/src/drag.js
@@ -38,10 +38,10 @@ ChartInternal.prototype.drag = function(mouse) {
   main
     .selectAll('.' + CLASS.shapes)
     .selectAll('.' + CLASS.shape)
-    .filter(function(d) {
-      return config.data_selection_isselectable(d)
-    })
     .each(function(d, i) {
+      if (!config.data_selection_isselectable(d)) {
+        return
+      }
       var shape = d3.select(this),
         isSelected = shape.classed(CLASS.SELECTED),
         isIncluded = shape.classed(CLASS.INCLUDED),


### PR DESCRIPTION
Fix for the issue #2793 

Because of the pre filter the index for the point was coming incorrect in mouse drag handler. Removed the filter and applied the check for isselectable inside the each loop. 
