### PR TITLE
Fix for #2813. Fixed trailing solid line for null values in case of data regions

### DIFF
--- a/src/shape.line.ts
+++ b/src/shape.line.ts
@@ -295,6 +295,9 @@ ChartInternal.prototype.lineWithRegions = function(d, x, y, _regions) {
 
   // Generate
   for (i = 0; i < d.length; i++) {
+    if (!d[i].value) {
+      continue;
+    }
     // Draw as normal
     if (isUndefined(regions) || !isWithinRegions(d[i].x, regions)) {
       s += ' ' + xValue(d[i]) + ' ' + yValue(d[i])


### PR DESCRIPTION
Checking if the value is null before plotting the line region (dashed line). If the value is null then there is no need to add the point in the SVG path. Without this check chart plots a solid line for data points with null value. Please refer to the description in the issue #2813.

