### PR TITLE
Security: Path traversal risk in file-reading helper methods

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,21 +1,30 @@
 helpers do
   def js_as_plain(id)
-    f = open("docs/js/samples/" + id + ".js")
-    js = f.read
-    f.close
-    js
+    raise ArgumentError unless id =~ /\A[a-zA-Z0-9_-]+\z/
+
+    base = File.expand_path('docs/js/samples', __dir__)
+    path = File.expand_path("#{id}.js", base)
+    raise ArgumentError unless path.start_with?(base + File::SEPARATOR)
+
+    File.read(path)
   end
   def data_as_plain(name)
-    f = open("docs/data/" + name)
-    data = f.read
-    f.close
-    data
+    raise ArgumentError unless name =~ /\A[a-zA-Z0-9._-]+\z/
+
+    base = File.expand_path('docs/data', __dir__)
+    path = File.expand_path(name, base)
+    raise ArgumentError unless path.start_with?(base + File::SEPARATOR)
+
+    File.read(path)
   end
   def css_as_plain(name)
-    f = open("docs/css/samples/" + name)
-    css = f.read
-    f.close
-    css
+    raise ArgumentError unless name =~ /\A[a-zA-Z0-9._-]+\z/
+
+    base = File.expand_path('docs/css/samples', __dir__)
+    path = File.expand_path(name, base)
+    raise ArgumentError unless path.start_with?(base + File::SEPARATOR)
+
+    File.read(path)
   end
   def get_css_name(path)
     path.gsub('.html', '')


### PR DESCRIPTION
## Problem

Helper methods build file paths by string concatenation (e.g., `open("docs/js/samples/" + id + ".js")`) without sanitizing `id`/`name`. If these values can be influenced externally, attackers may read unintended files via traversal sequences.

**Severity**: `medium`
**File**: `config.rb`

## Solution

Validate inputs against strict allowlists (expected sample names), normalize paths, and enforce that resolved paths remain within intended directories before opening files.

## Changes

- `config.rb` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
