### PR TITLE
Quality: Inconsistent callback context for tooltip hide handler

### DIFF
--- a/src/api.tooltip.ts
+++ b/src/api.tooltip.ts
@@ -36,5 +36,5 @@ Chart.prototype.tooltip.hide = function() {
   // TODO: get target data by checking the state of focus
   this.internal.dispatchEvent('mouseout', 0)
 
-  this.internal.config.tooltip_onhide.call(this)
+  this.internal.config.tooltip_onhide.call(this.internal)
 }


### PR DESCRIPTION
## Problem

`tooltip.show` invokes `tooltip_onshow` with `this` bound to the internal chart object (`$$`), but `tooltip.hide` invokes `tooltip_onhide` with `this` bound to the public chart instance. This inconsistency can break user callbacks that rely on a stable context and internal fields.

**Severity**: `high`
**File**: `src/api.tooltip.ts`

## Solution

Call `tooltip_onhide` with the same context style used by `tooltip_onshow` (for example: `this.internal.config.tooltip_onhide.call(this.internal)`), and add a regression test asserting callback `this` consistency.

## Changes

- `src/api.tooltip.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
