### PR TITLE
ci: migrate the test job to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,5 @@
 version: 2
 
-node12: &node12
-  working_directory: ~/c3
-  docker:
-    - image: circleci/node:12-browsers
-
-node14: &node14
-  working_directory: ~/c3
-  docker:
-    - image: circleci/node:14-browsers
-
 restore_modules_cache: &restore_modules_cache
   restore_cache:
     keys:
@@ -22,36 +12,7 @@ save_modules_cache: &save_modules_cache
     key: npm-4-{{ checksum "package.json" }}
     paths: ./node_modules
 
-install_and_test: &install_and_test
-  steps:
-    - checkout
-    - run:
-        name: Display versions
-        command: |
-          echo "node $(node -v)"
-          echo "npm v$(npm --version)"
-          echo "$(google-chrome --version)"
-    - *restore_modules_cache
-    - run:
-        name: Installing Dependencies
-        command: yarn
-    - *save_modules_cache
-    - run: yarn test
-    - run: yarn codecov
-    - store_artifacts:
-        path: htdocs
-        destination: htdocs
-    - run: npx status-back -s -c circleci/htdocs -r c3js/c3 "preview build succes!" "https://${CIRCLE_BUILD_NUM}-11496279-gh.circle-artifacts.com/0/htdocs/index.html"
-
 jobs:
-  test_on_node12:
-    <<: *node12
-    <<: *install_and_test
-
-  test_on_node14:
-    <<: *node14
-    <<: *install_and_test
-
   docs:
     docker:
       - image: circleci/ruby:2.4-node
@@ -80,6 +41,4 @@ workflows:
   version: 2
   test:
     jobs:
-      - test_on_node12
-      - test_on_node14
       - docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - run: yarn
+      - run: yarn test
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,12 @@ module.exports = config =>
       }
     },
     reporters: ['spec', 'karma-typescript'],
-    browsers: ['Chrome'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu']
+      }
+    },
+    browsers: [process.env.CI ? 'ChromeHeadlessCI' : 'Chrome'],
     singleRun: true
   })


### PR DESCRIPTION
CircleCI's test_on_node12/test_on_node14 images no longer satisfy transitive dependency engine requirements — `node-releases` needs Node >=18 after the @babel/core bump in #2921. Rather than bump the CircleCI images, this moves the `test` job to GitHub Actions on Node `lts/*`.

- Adds `.github/workflows/ci.yml`: checkout, setup-node, `yarn`, `yarn test` (build + lint + karma), coverage via `codecov-action`.
- karma.conf.js: adds a `ChromeHeadlessCI` launcher (`--no-sandbox --disable-gpu`) used when `CI` is set, since GH Actions runners have no display server. Local dev still uses headed `Chrome`.
- Removes the `test_on_node12`/`test_on_node14` CircleCI jobs and the now-unused `node24` anchor.
- The `docs` job stays on CircleCI for now (untouched).

478/479 tests pass locally under the new headless setup (1 pre-existing skip).