### PR TITLE
ci: scope trigger to the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restricts the ci workflow to only run on pushes/PRs targeting `main`, instead of every branch.