### PR TITLE
fix: pin rollup-plugin-typescript2's include patterns explicitly

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ export default [
       banner: `/* @license C3.js v${pkg.version} | (c) C3 Team and other contributors | http://c3js.org/ */`,
       globals: { d3: 'd3' }
     },
-    plugins: [typescript()],
+    plugins: [typescript({ include: ['*.ts', '*.tsx', '**/*.ts', '**/*.tsx'] })],
     external: ['d3']
   }
 ]


### PR DESCRIPTION
`rollup-plugin-typescript2`'s default include glob (`*.ts+(|x)`) relies on picomatch's extglob handling. picomatch `>=2.3.0` changed that behavior so the pattern no longer matches `.ts` files at all — verified locally:

```js
picomatch('**/*.ts+(|x)')('src/core.ts')
// 2.2.2 -> true
// 2.3.2 -> false
```

Without a match, rollup receives raw TypeScript source instead of the transformed output and fails with `Unexpected token`. This is currently blocking #2918 (picomatch 2.2.2 → 2.3.2).

Passing explicit, non-extglob include patterns sidesteps the broken interaction entirely, regardless of which picomatch version ends up resolved.